### PR TITLE
Submit signed transactions instead of messages

### DIFF
--- a/da/lazyledger/encoding.go
+++ b/da/lazyledger/encoding.go
@@ -1,0 +1,20 @@
+package lazyledger
+
+import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/lazyledger/lazyledger-app/app/params"
+)
+
+// RegisterAccountInterface registers the authtypes.AccountI interface to the
+// interface registery in the provided encoding config
+func RegisterAccountInterface(conf params.EncodingConfig) params.EncodingConfig {
+	conf.InterfaceRegistry.RegisterInterface(
+		"cosmos.auth.v1beta1.BaseAccount",
+		(*authtypes.AccountI)(nil),
+	)
+	conf.InterfaceRegistry.RegisterImplementations(
+		(*authtypes.AccountI)(nil),
+		&authtypes.BaseAccount{},
+	)
+	return conf
+}

--- a/da/lazyledger/lazyledger.go
+++ b/da/lazyledger/lazyledger.go
@@ -187,7 +187,10 @@ func (ll *LazyLedger) sign(msg *apptypes.MsgWirePayForMessage) (*tx.BroadcastTxR
 		Sequence: 0,
 	}
 
-	txBuilder.SetSignatures(sigV2)
+	err = txBuilder.SetSignatures(sigV2)
+	if err != nil {
+		return nil, err
+	}
 
 	accNum, seq, err := ll.queryAccount()
 	if err != nil {

--- a/da/lazyledger/lazyledger.go
+++ b/da/lazyledger/lazyledger.go
@@ -9,14 +9,10 @@ import (
 	"github.com/pelletier/go-toml"
 	"google.golang.org/grpc"
 
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
-	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/lazyledger/lazyledger-app/app/params"
+	appclient "github.com/lazyledger/lazyledger-app/x/lazyledgerapp/client"
 	apptypes "github.com/lazyledger/lazyledger-app/x/lazyledgerapp/types"
 
 	"github.com/lazyledger/optimint/da"
@@ -53,7 +49,6 @@ type Config struct {
 
 type LazyLedger struct {
 	config Config
-	encCfg params.EncodingConfig
 	logger log.Logger
 
 	keyring keyring.Keyring
@@ -70,8 +65,6 @@ func (ll *LazyLedger) Init(config []byte, logger log.Logger) error {
 	if err != nil {
 		return err
 	}
-
-	ll.encCfg = RegisterAccountInterface(params.MakeEncodingConfig())
 
 	var userInput io.Reader
 	// TODO(tzdybal): this means interactive reading from stdin - shouldn't we replace this somehow?
@@ -98,7 +91,10 @@ func (ll *LazyLedger) SubmitBlock(block *types.Block) da.ResultSubmitBlock {
 		return da.ResultSubmitBlock{Code: da.StatusError, Message: err.Error()}
 	}
 
-	err = ll.callRPC(msg)
+	ctx, cancel := context.WithTimeout(context.TODO(), ll.config.Timeout)
+	defer cancel()
+
+	ll.callRPC(ctx, msg)
 	if err != nil {
 		return da.ResultSubmitBlock{Code: da.StatusError, Message: err.Error()}
 	}
@@ -106,33 +102,39 @@ func (ll *LazyLedger) SubmitBlock(block *types.Block) da.ResultSubmitBlock {
 	return da.ResultSubmitBlock{Code: da.StatusSuccess}
 }
 
-func (ll *LazyLedger) callRPC(msg *apptypes.MsgWirePayForMessage) error {
-	// query account and sequence numbers
-	accNum, seq, err := ll.queryAccount()
+func (ll *LazyLedger) callRPC(ctx context.Context, msg *apptypes.MsgWirePayForMessage) error {
+	info, err := ll.keyring.Key(ll.config.KeyringAccName)
 	if err != nil {
 		return err
 	}
 
-	signedTx, err := ll.buildTx(msg, accNum, seq)
+	b := appclient.NewBuilder(info.GetAddress(), ll.config.ChainID)
+
+	err = b.UpdateAccountNumber(ctx, ll.rpcClient)
 	if err != nil {
 		return err
 	}
 
-	// Generated Protobuf-encoded bytes.
-	txBytes, err := ll.encCfg.TxConfig.TxEncoder()(signedTx)
+	coin := sdk.Coin{
+		Denom:  "token",
+		Amount: sdk.NewInt(10),
+	}
+	b.SetFeeAmount(sdk.NewCoins(coin))
+
+	b.SetGasLimit(ll.config.GasLimit)
+
+	signedTx, err := b.BuildSignedTx(msg, ll.keyring)
 	if err != nil {
 		return err
 	}
 
-	txClient := tx.NewServiceClient(ll.rpcClient)
+	rawTx, err := b.EncodeTx(signedTx)
+	if err != nil {
+		return err
+	}
 
-	_, err = txClient.BroadcastTx(
-		context.Background(),
-		&tx.BroadcastTxRequest{
-			// probably need to change this
-			Mode:    tx.BroadcastMode_BROADCAST_MODE_SYNC,
-			TxBytes: txBytes,
-		})
+	// wait for the transaction to be confirmed in a block
+	_, err = appclient.BroadcastTx(ctx, ll.rpcClient, tx.BroadcastMode_BROADCAST_MODE_BLOCK, rawTx)
 	if err != nil {
 		return err
 	}
@@ -169,117 +171,5 @@ func (ll *LazyLedger) preparePayForMessage(block *types.Block) (*apptypes.MsgWir
 		return nil, err
 	}
 
-	// run message checks
-	err = msg.ValidateBasic()
-	if err != nil {
-		return nil, err
-	}
-
-	return msg, nil
-}
-
-func (ll *LazyLedger) buildTx(msg *apptypes.MsgWirePayForMessage, accNum, seq uint64) (authsigning.Tx, error) {
-	// Create a new TxBuilder.
-	txBuilder := ll.encCfg.TxConfig.NewTxBuilder()
-
-	txBuilder = ll.setFees(txBuilder)
-
-	err := txBuilder.SetMsgs(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := ll.keyring.Key(ll.config.KeyringAccName)
-	if err != nil {
-		return nil, err
-	}
-
-	// we must first set an empty signature in order generate
-	// the correct sign bytes
-	sigV2 := signing.SignatureV2{
-		PubKey: info.GetPubKey(),
-		Data: &signing.SingleSignatureData{
-			SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
-			Signature: nil,
-		},
-		Sequence: seq,
-	}
-
-	// set the empty signature
-	err = txBuilder.SetSignatures(sigV2)
-	if err != nil {
-		return nil, err
-	}
-
-	// generate the new signing data
-	signerData := authsigning.SignerData{
-		ChainID:       ll.config.ChainID,
-		AccountNumber: accNum,
-		Sequence:      seq,
-	}
-
-	// Generate the bytes to be signed.
-	bytesToSign, err := ll.encCfg.TxConfig.SignModeHandler().GetSignBytes(
-		signing.SignMode_SIGN_MODE_DIRECT,
-		signerData,
-		txBuilder.GetTx(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Sign those bytes using the keyring
-	sigBytes, _, err := ll.keyring.Sign(ll.config.KeyringAccName, bytesToSign)
-	if err != nil {
-		return nil, err
-	}
-
-	// Construct the SignatureV2 struct
-	sigV2 = signing.SignatureV2{
-		PubKey: info.GetPubKey(),
-		Data: &signing.SingleSignatureData{
-			SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
-			Signature: sigBytes,
-		},
-		Sequence: seq,
-	}
-
-	err = txBuilder.SetSignatures(sigV2)
-	if err != nil {
-		return nil, err
-	}
-
-	return txBuilder.GetTx(), nil
-}
-
-func (ll *LazyLedger) setFees(builder client.TxBuilder) client.TxBuilder {
-	coin := sdk.Coin{
-		Denom:  "token",
-		Amount: sdk.NewInt(int64(ll.config.FeeAmount)),
-	}
-	// todo(evan): don't hardcode the gas limit
-	builder.SetGasLimit(ll.config.GasLimit)
-	builder.SetFeeAmount(sdk.NewCoins(coin))
-	return builder
-}
-
-// queryAccount fetches the account number and sequence number from the lazyledger-app node
-func (ll *LazyLedger) queryAccount() (accNum uint64, seqNum uint64, err error) {
-	qclient := authtypes.NewQueryClient(ll.rpcClient)
-	resp, err := qclient.Account(
-		context.TODO(),
-		&authtypes.QueryAccountRequest{Address: ll.config.From},
-	)
-	if err != nil {
-		return accNum, seqNum, err
-	}
-
-	var acc authtypes.AccountI
-	err = ll.encCfg.Marshaler.UnpackAny(resp.Account, &acc)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	accNum, seqNum = acc.GetAccountNumber(), acc.GetSequence()
-	return
+	return msg, msg.ValidateBasic()
 }

--- a/da/lazyledger/lazyledger.go
+++ b/da/lazyledger/lazyledger.go
@@ -25,7 +25,6 @@ type Config struct {
 	PubKey      []byte
 	BaseRateMax uint64 // currently not used
 	TipRateMax  uint64 // currently not used
-	From        string
 
 	// temporary fee fields
 	GasLimit  uint64

--- a/da/lazyledger/lazyledger.go
+++ b/da/lazyledger/lazyledger.go
@@ -2,7 +2,6 @@ package lazyledger
 
 import (
 	"context"
-	"io"
 	"os"
 	"time"
 
@@ -66,9 +65,8 @@ func (ll *LazyLedger) Init(config []byte, logger log.Logger) error {
 		return err
 	}
 
-	var userInput io.Reader
 	// TODO(tzdybal): this means interactive reading from stdin - shouldn't we replace this somehow?
-	userInput = os.Stdin
+	userInput := os.Stdin
 	ll.keyring, err = keyring.New(ll.config.KeyringAccName, ll.config.Backend, ll.config.RootDir, userInput)
 	return err
 }
@@ -94,7 +92,7 @@ func (ll *LazyLedger) SubmitBlock(block *types.Block) da.ResultSubmitBlock {
 	ctx, cancel := context.WithTimeout(context.TODO(), ll.config.Timeout)
 	defer cancel()
 
-	ll.callRPC(ctx, msg)
+	err = ll.callRPC(ctx, msg)
 	if err != nil {
 		return da.ResultSubmitBlock{Code: da.StatusError, Message: err.Error()}
 	}

--- a/da/lazyledger/lazyledger_test.go
+++ b/da/lazyledger/lazyledger_test.go
@@ -52,7 +52,8 @@ func TestSubmission(t *testing.T) {
 
 	ll := &LazyLedger{}
 	keyring := generateKeyring(t, "test")
-	key, err := keyring.Key("test")
+	key, err := keyring.Key("test-account")
+	require.NoError(err)
 	keyStr := ""
 	for _, b := range key.GetPubKey().Bytes() {
 		keyStr += strconv.Itoa(int(b)) + ", "
@@ -60,8 +61,9 @@ func TestSubmission(t *testing.T) {
 	require.NoError(err)
 	conf := "PubKey=[" + keyStr + "]" + `
 	Backend = 'test'
-	From = 'test'
-	Address = '127.0.0.1:9090'
+	From = 'cosmos1xgx6xf23sqaas6yn9k0upw4m5lyzh725jhnc2x'
+	KeyringAccName = 'test-account'
+	RPCAddress = '127.0.0.1:9090'
 	NamespaceID = [3, 2, 1, 0, 3, 2, 1, 0]
 	`
 	err = ll.Init([]byte(conf), nil)
@@ -87,5 +89,15 @@ func generateKeyring(t *testing.T, accts ...string) keyring.Keyring {
 		}
 	}
 
+	_, err := kb.NewAccount(testAccName, testMnemo, "1234", "", hd.Secp256k1)
+	if err != nil {
+		panic(err)
+	}
+
 	return kb
 }
+
+const (
+	testMnemo   = `ramp soldier connect gadget domain mutual staff unusual first midnight iron good deputy wage vehicle mutual spike unlock rocket delay hundred script tumble choose`
+	testAccName = "test-account"
+)

--- a/da/lazyledger/lazyledger_test.go
+++ b/da/lazyledger/lazyledger_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/lazyledger/optimint/da"
 	"github.com/lazyledger/optimint/types"
 	"github.com/stretchr/testify/assert"
@@ -86,44 +85,6 @@ func testConfig(key keyring.Info) string {
 
 	`, keyStr, key.GetAddress().String())
 	return conf
-}
-
-func Test_buildTx(t *testing.T) {
-	kr := generateKeyring(t)
-	key, err := kr.Key("test-account")
-	require.NoError(t, err)
-	conf := testConfig(key)
-	ll := LazyLedger{}
-	err = ll.Init([]byte(conf), nil)
-	require.NoError(t, err)
-	ll.keyring = kr
-
-	key, err = ll.keyring.Key("test-account")
-	require.NoError(t, err)
-
-	block := &types.Block{Header: types.Header{
-		Height: 1,
-	}}
-
-	msg, err := ll.preparePayForMessage(block)
-	require.NoError(t, err)
-
-	signedTx, err := ll.buildTx(msg, 0, 0)
-	require.NoError(t, err)
-
-	sigs, err := signedTx.GetSignaturesV2()
-	require.NoError(t, err)
-
-	signerData := authsigning.SignerData{
-		ChainID:       "test",
-		AccountNumber: 0,
-		Sequence:      0,
-	}
-
-	// Generated Protobuf-encoded bytes.
-	require.NoError(t, err)
-	err = authsigning.VerifySignature(key.GetPubKey(), signerData, sigs[0].Data, ll.encCfg.TxConfig.SignModeHandler(), signedTx)
-	require.NoError(t, err)
 }
 
 func generateKeyring(t *testing.T, accts ...string) keyring.Keyring {

--- a/da/lazyledger/lazyledger_test.go
+++ b/da/lazyledger/lazyledger_test.go
@@ -43,7 +43,7 @@ func TestConfiguration(t *testing.T) {
 }
 
 func TestSubmission(t *testing.T) {
-	t.Skip("unfinished test/implementation")
+	// t.Skip("unfinished test/implementation")
 	assert := assert.New(t)
 	require := require.New(t)
 	block := &types.Block{Header: types.Header{
@@ -61,7 +61,7 @@ func TestSubmission(t *testing.T) {
 	conf := "PubKey=[" + keyStr + "]" + `
 	Backend = 'test'
 	From = 'test'
-	Address = '127.0.0.1:9191'
+	Address = '127.0.0.1:9090'
 	NamespaceID = [3, 2, 1, 0, 3, 2, 1, 0]
 	`
 	err = ll.Init([]byte(conf), nil)

--- a/da/lazyledger/lazyledger_test.go
+++ b/da/lazyledger/lazyledger_test.go
@@ -43,7 +43,7 @@ func TestConfiguration(t *testing.T) {
 }
 
 func TestSubmission(t *testing.T) {
-	// t.Skip("unfinished test/implementation")
+	t.Skip("unfinished test/implementation")
 	assert := assert.New(t)
 	require := require.New(t)
 	block := &types.Block{Header: types.Header{

--- a/da/lazyledger/lazyledger_test.go
+++ b/da/lazyledger/lazyledger_test.go
@@ -68,6 +68,7 @@ func TestSubmission(t *testing.T) {
 	assert.Equal(da.StatusSuccess, result.Code)
 }
 
+// nolint: unused
 func testConfig(key keyring.Info) string {
 	keyStr := ""
 	for _, b := range key.GetPubKey().Bytes() {
@@ -87,6 +88,7 @@ func testConfig(key keyring.Info) string {
 	return conf
 }
 
+// nolint: unused
 func generateKeyring(t *testing.T, accts ...string) keyring.Keyring {
 	t.Helper()
 	kb := keyring.NewInMemory()

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/libp2p/go-libp2p-discovery v0.5.0
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
-	github.com/minio/sha256-simd v0.1.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/pelletier/go-toml v1.9.0
 	github.com/prometheus/client_golang v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.4.3
 	github.com/ipfs/go-log v1.0.4
-	github.com/lazyledger/lazyledger-app v0.0.0-20210421070454-76641cc80638
+	github.com/lazyledger/lazyledger-app v0.0.0-20210610204649-0c5a9b3f170b
 	github.com/lazyledger/lazyledger-core v0.0.0-20210219190522-0eccfb24e2aa
 	github.com/libp2p/go-libp2p v0.13.0
 	github.com/libp2p/go-libp2p-core v0.8.5

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/lazyledger/cosmos-sdk v0.40.0-rc5.0.20210121152417-3addd7f65d1c h1:OF
 github.com/lazyledger/cosmos-sdk v0.40.0-rc5.0.20210121152417-3addd7f65d1c/go.mod h1:pPx3/tAjdExEctV+nKzvNeedZcvuys5fUD0A3r5XX20=
 github.com/lazyledger/go-leopard v0.0.0-20200604113236-298f93361181 h1:mUeCGuCgjZVadW4CzA2dMBq7p2BqaoCfpnKjxMmSaSE=
 github.com/lazyledger/go-leopard v0.0.0-20200604113236-298f93361181/go.mod h1:v1o1CRihQ9i7hizx23KK4aR79lxA6VDUIzUCfDva0XQ=
-github.com/lazyledger/lazyledger-app v0.0.0-20210421070454-76641cc80638 h1:eTyDJGbJxrs/SxLC0JkglKlPLOiPR1AeaSK9s3IX9ZU=
-github.com/lazyledger/lazyledger-app v0.0.0-20210421070454-76641cc80638/go.mod h1:YXf0VFCIWp8uaeEKf89aW5jR32syrq5vyxbL62TQFfU=
+github.com/lazyledger/lazyledger-app v0.0.0-20210610204649-0c5a9b3f170b h1:bbqIxmrZeDBHAVphmPsYdDQ+7ALxEbh5gI2K53ieOUg=
+github.com/lazyledger/lazyledger-app v0.0.0-20210610204649-0c5a9b3f170b/go.mod h1:YXf0VFCIWp8uaeEKf89aW5jR32syrq5vyxbL62TQFfU=
 github.com/lazyledger/lazyledger-core v0.0.0-20210115223437-eff282ad2592/go.mod h1:yNWM9NVGWzSqRS56TL5cVdD6fS0eoxZlCZNHRvxjneE=
 github.com/lazyledger/lazyledger-core v0.0.0-20210122184344-b83e6766973c/go.mod h1:w3QtViDbWfzQ7Jk5uRAKnnfGGJswYTgZLHMZyeyGELg=
 github.com/lazyledger/lazyledger-core v0.0.0-20210219190522-0eccfb24e2aa h1:MFi5bQnxlFsrWPuld0gT3N6I3K9DcD2YBMwVP2Evwfo=


### PR DESCRIPTION
This PR uses signed `sdk.Transaction`s instead of messages. It also uses the port 9090 to broadcast that tx via grpc. Before this PR can be reviewed, it still needs a bit of polish, along with the ability to look up the sequence and account numbers for the account submitting the `WirePayForMsg`.

closes: #60 