### PR TITLE
Missing RPC methods

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -169,6 +169,10 @@ func (n *Node) OnStart() error {
 	return nil
 }
 
+func (n *Node) GetGenesis() *types.GenesisDoc {
+	return n.genesis
+}
+
 // OnStop is a part of Service interface.
 func (n *Node) OnStop() {
 	err := n.dalc.Stop()

--- a/node/node.go
+++ b/node/node.go
@@ -169,7 +169,7 @@ func (n *Node) OnStart() error {
 	return nil
 }
 
-func (n *Node) GetGenesis() *types.GenesisDoc {
+func (n *Node) GetGenesis() *tmtypes.GenesisDoc {
 	return n.genesis
 }
 

--- a/rpcclient/local.go
+++ b/rpcclient/local.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	defaultPerPage = 30
+	maxPerPage     = 100
+
 	// TODO(tzdybal): make this configurable
 	subscribeTimeout = 5 * time.Second
 )
@@ -250,9 +253,8 @@ func (l *Local) Unsubscribe(ctx context.Context, subscriber, query string) error
 	return l.EventBus.Unsubscribe(ctx, subscriber, q)
 }
 
-func (l *Local) Genesis(ctx context.Context) (*ctypes.ResultGenesis, error) {
-	// needs genesis provider
-	panic("Genesis - not implemented!")
+func (l *Local) Genesis(_ context.Context) (*ctypes.ResultGenesis, error) {
+	return &ctypes.ResultGenesis{Genesis: l.node.GetGenesis()}, nil
 }
 
 func (l *Local) GenesisChunked(context.Context, uint) (*ctypes.ResultGenesisChunk, error) {
@@ -364,14 +366,23 @@ func (l *Local) BroadcastEvidence(ctx context.Context, evidence types.Evidence) 
 	panic("BroadcastEvidence - not implemented!")
 }
 
-func (l *Local) UnconfirmedTxs(ctx context.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error) {
-	// needs mempool
-	panic("UnconfirmedTxs - not implemented!")
+func (l *Local) UnconfirmedTxs(ctx context.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
+	// reuse per_page validator
+	limit := validatePerPage(limitPtr)
+
+	txs := l.node.Mempool.ReapMaxTxs(limit)
+	return &ctypes.ResultUnconfirmedTxs{
+		Count:      len(txs),
+		Total:      l.node.Mempool.Size(),
+		TotalBytes: l.node.Mempool.TxsBytes(),
+		Txs:        txs}, nil
 }
 
 func (l *Local) NumUnconfirmedTxs(ctx context.Context) (*ctypes.ResultUnconfirmedTxs, error) {
-	// needs mempool
-	panic("NumUnconfirmedTxs - not implemented!")
+	return &ctypes.ResultUnconfirmedTxs{
+		Count:      l.node.Mempool.Size(),
+		Total:      l.node.Mempool.Size(),
+		TotalBytes: l.node.Mempool.TxsBytes()}, nil
 }
 
 func (l *Local) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
@@ -444,4 +455,18 @@ func (l *Local) query() proxy.AppConnQuery {
 
 func (l *Local) snapshot() proxy.AppConnSnapshot {
 	return l.node.ProxyApp().Snapshot()
+}
+
+func validatePerPage(perPagePtr *int) int {
+	if perPagePtr == nil { // no per_page parameter
+		return defaultPerPage
+	}
+
+	perPage := *perPagePtr
+	if perPage < 1 {
+		return defaultPerPage
+	} else if perPage > maxPerPage {
+		return maxPerPage
+	}
+	return perPage
 }

--- a/rpcclient/local.go
+++ b/rpcclient/local.go
@@ -269,7 +269,25 @@ func (l *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) 
 
 func (l *Local) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, error) {
 	// needs P2P layer
-	panic("NetInfo - not implemented!")
+
+	res := ctypes.ResultNetInfo{
+		Listening: true,
+	}
+	for _, ma := range l.node.P2P.Addrs() {
+		res.Listeners = append(res.Listeners, ma.String())
+	}
+	peers := l.node.P2P.Peers()
+	res.NPeers = len(peers)
+	for _, peer := range peers {
+		res.Peers = append(res.Peers, ctypes.Peer{
+			NodeInfo:         peer.NodeInfo,
+			IsOutbound:       peer.IsOutbound,
+			ConnectionStatus: peer.ConnectionStatus,
+			RemoteIP:         peer.RemoteIP,
+		})
+	}
+
+	return &res, nil
 }
 
 func (l *Local) DumpConsensusState(ctx context.Context) (*ctypes.ResultDumpConsensusState, error) {


### PR DESCRIPTION
Implement missing RPC methods:

- [x] Genesis
- [ ] BlockchainInfo
- [x] NetInfo
- [ ] DumpConsensus
- [ ] State
- [ ] ConsensusState
- [ ] ConsensusParams
- [x] Health
- [ ] Block
- [ ] BlockByHash
- [ ] BlockResults
- [ ] Commit
- [ ] Validators
- [ ] Tx
- [ ] TxSearch
- [ ] BroadcastEvidence
- [x] UnconfirmedTxs
- [x] NumUnconfirmedTxs

Resolves #49.