### PR TITLE
Fix typos in node/node.go

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -190,7 +190,7 @@ func (n *Node) EventBus() *types.EventBus {
 	return n.eventBus
 }
 
-// ProxyApp returns ABCI proxy connections to comminicate with aplication.
+// ProxyApp returns ABCI proxy connections to communicate with application.
 func (n *Node) ProxyApp() proxy.AppConns {
 	return n.proxyApp
 }


### PR DESCRIPTION
Fix some typos found in goreportcard.