### PR TITLE
Block Propagation

### DIFF
--- a/node/aggregator.go
+++ b/node/aggregator.go
@@ -31,6 +31,8 @@ type aggregator struct {
 	dalc     da.DataAvailabilityLayerClient
 	executor *state.BlockExecutor
 
+	newHeaders chan *types.Header
+
 	logger log.Logger
 }
 
@@ -73,6 +75,7 @@ func newAggregator(
 		store:       store,
 		executor:    exec,
 		dalc:        dalc,
+		newHeaders:  make(chan *types.Header),
 		logger:      logger,
 	}
 
@@ -161,7 +164,9 @@ func (a *aggregator) broadcastBlock(ctx context.Context, block *types.Block) err
 	res := a.dalc.SubmitBlock(block)
 	if res.Code != da.StatusSuccess {
 		return fmt.Errorf("DA layer submission failed: %s", res.Message)
-
 	}
+
+	a.newHeaders <- &block.Header
+
 	return nil
 }

--- a/node/aggregator.go
+++ b/node/aggregator.go
@@ -31,7 +31,7 @@ type aggregator struct {
 	dalc     da.DataAvailabilityLayerClient
 	executor *state.BlockExecutor
 
-	newHeaders chan *types.Header
+	headerCh chan *types.Header
 
 	logger log.Logger
 }
@@ -75,7 +75,7 @@ func newAggregator(
 		store:       store,
 		executor:    exec,
 		dalc:        dalc,
-		newHeaders:  make(chan *types.Header),
+		headerCh:  make(chan *types.Header),
 		logger:      logger,
 	}
 
@@ -166,7 +166,7 @@ func (a *aggregator) broadcastBlock(ctx context.Context, block *types.Block) err
 		return fmt.Errorf("DA layer submission failed: %s", res.Message)
 	}
 
-	a.newHeaders <- &block.Header
+	a.headerCh <- &block.Header
 
 	return nil
 }

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -112,7 +112,7 @@ func createNode(n int, aggregator bool, keys []crypto.PrivKey, t *testing.T) (*N
 		keys[n],
 		proxy.NewLocalClientCreator(app),
 		&types.GenesisDoc{ChainID: "test"},
-		log.TestingLogger())
+		log.TestingLogger().With("node", n))
 	require.NoError(err)
 	require.NotNil(node)
 

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 	"time"
 
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/libs/log"
-	"github.com/tendermint/tendermint/proxy"
-	"github.com/tendermint/tendermint/types"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/optimint/config"
 	"github.com/celestiaorg/optimint/mocks"

--- a/node/node.go
+++ b/node/node.go
@@ -241,7 +241,7 @@ func (n *Node) ProxyApp() proxy.AppConns {
 // transaction. If the transaction is valid, then it is added to the mempool
 func newTxValidator(pool mempool.Mempool, poolIDs *mempoolIDs, logger log.Logger) p2p.GossipValidator {
 	return func(m *p2p.GossipMessage) bool {
-		logger.Debug("transaction of size %d recieved", "bytes", len(m.Data))
+		logger.Debug("transaction received", "bytes", len(m.Data))
 		checkTxResCh := make(chan *abci.Response, 1)
 		err := pool.CheckTx(m.Data, func(resp *abci.Response) {
 			checkTxResCh <- resp

--- a/node/node.go
+++ b/node/node.go
@@ -168,7 +168,7 @@ func (n *Node) headerReadLoop(ctx context.Context) {
 func (n *Node) headerPublishLoop(ctx context.Context) {
 	for {
 		select {
-		case header := <-n.aggregator.newHeaders:
+		case header := <-n.aggregator.headerCh:
 			headerBytes, err := header.MarshalBinary()
 			if err != nil {
 				n.Logger.Error("failed to serialize block header", "error", err)

--- a/node/node.go
+++ b/node/node.go
@@ -79,6 +79,7 @@ func NewNode(ctx context.Context, conf config.NodeConfig, nodeKey crypto.PrivKey
 
 	var baseKV store.KVStore
 	if conf.RootDir == "" && conf.DBPath == "" { // this is used for testing
+		logger.Info("WARNING: working in in-memory mode")
 		baseKV = store.NewInMemoryKVStore()
 	} else {
 		baseKV = store.NewKVStore(conf.RootDir, conf.DBPath, "optimint")

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -52,10 +52,10 @@ type Client struct {
 	disc *discovery.RoutingDiscovery
 
 	txGossiper  *Gossiper
-	txValidator pubsub.Validator
+	txValidator GossipValidator
 
 	headerGossiper  *Gossiper
-	headerValidator pubsub.Validator
+	headerValidator GossipValidator
 	headerHandler   GossipHandler
 
 	// cancel is used to cancel context passed to libp2p functions
@@ -153,7 +153,7 @@ func (c *Client) SetTxHandler(handler GossipHandler) {
 }
 
 // SetTxValidator sets the callback function, that will be invoked during message gossiping.
-func (c *Client) SetTxValidator(val pubsub.Validator) {
+func (c *Client) SetTxValidator(val GossipValidator) {
 	c.txValidator = val
 }
 
@@ -164,7 +164,7 @@ func (c *Client) GossipHeader(ctx context.Context, headerBytes []byte) error {
 }
 
 // SetHeaderValidator sets the callback function, that will be invoked after block header is received from P2P network.
-func (c *Client) SetHeaderValidator(validator pubsub.Validator) {
+func (c *Client) SetHeaderValidator(validator GossipValidator) {
 	c.headerValidator = validator
 }
 

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -51,8 +51,7 @@ type Client struct {
 	dht  *dht.IpfsDHT
 	disc *discovery.RoutingDiscovery
 
-	txGossiper  *Gossiper
-	txValidator pubsub.Validator
+	txGossiper *Gossiper
 
 	headerGossiper *Gossiper
 
@@ -150,7 +149,7 @@ func (c *Client) SetTxHandler(handler GossipHandler) {
 }
 
 func (c *Client) SetTxValidator(val pubsub.Validator) {
-	c.txValidator = val
+	c.txGossiper.validator = val
 }
 
 // GossipHeader sends the block header to the P2P network.
@@ -267,8 +266,8 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 		return err
 	}
 
-	if c.txValidator != nil {
-		err = ps.RegisterTopicValidator(c.getTxTopic(), c.txValidator)
+	if c.txGossiper.validator != nil {
+		err = ps.RegisterTopicValidator(c.getTxTopic(), c.txGossiper.validator)
 		if err != nil {
 			return err
 		}

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"context"
 
+	"go.uber.org/multierr"
+
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -19,22 +21,40 @@ type GossipMessage struct {
 // GossipHandler is a callback function type.
 type GossipHandler func(*GossipMessage)
 
+// GossiperOption sets optional parameters of Gossiper.
+type GossiperOption func(*Gossiper) error
+
+// WithHandler option sets message handler to Gossiper.
+func WithHandler(handler GossipHandler) GossiperOption {
+	return func(g *Gossiper) error {
+		g.handler = handler
+		return nil
+	}
+}
+
+// WithValidator options registers topic validator for Gossiper.
+func WithValidator(validator pubsub.Validator) GossiperOption {
+	return func(g *Gossiper) error {
+		return g.ps.RegisterTopicValidator(g.topic.String(), validator)
+	}
+}
+
 // Gossiper is an abstraction of P2P publish subscribe mechanism.
 type Gossiper struct {
 	ownId peer.ID
 
-	topic     *pubsub.Topic
-	sub       *pubsub.Subscription
-	handler   GossipHandler
-	validator pubsub.Validator
+	ps      *pubsub.PubSub
+	topic   *pubsub.Topic
+	sub     *pubsub.Subscription
+	handler GossipHandler
 
 	logger log.Logger
 }
 
-// NewGossip creates new, ready to use instance of Gossiper.
+// NewGossiper creates new, ready to use instance of Gossiper.
 //
 // Returned Gossiper object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
-func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger) (*Gossiper, error) {
+func NewGossiper(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger, options ...GossiperOption) (*Gossiper, error) {
 	topic, err := ps.Join(topicStr)
 	if err != nil {
 		return nil, err
@@ -44,18 +64,32 @@ func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Lo
 	if err != nil {
 		return nil, err
 	}
-	return &Gossiper{
+	g := &Gossiper{
 		ownId:   host.ID(),
+		ps:      ps,
 		topic:   topic,
 		sub:     subscription,
 		handler: nil,
 		logger:  logger,
-	}, nil
+	}
+
+	for _, option := range options {
+		err := option(g)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return g, nil
 }
 
 func (g *Gossiper) Close() error {
+	err := g.ps.UnregisterTopicValidator(g.topic.String())
 	g.sub.Cancel()
-	return g.topic.Close()
+	return multierr.Combine(
+		err,
+		g.topic.Close(),
+	)
 }
 
 // Publish publishes data to gossip topic.

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -67,7 +67,7 @@ func (g *Gossip) ProcessMessages(ctx context.Context) {
 	for {
 		msg, err := g.sub.Next(ctx)
 		if err != nil {
-			g.logger.Error("failed to read transaction", "error", err)
+			g.logger.Error("failed to read message", "error", err)
 			return
 		}
 		if msg.GetFrom() == g.ownId {

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -23,9 +23,10 @@ type GossipHandler func(*GossipMessage)
 type Gossiper struct {
 	ownId peer.ID
 
-	topic   *pubsub.Topic
-	sub     *pubsub.Subscription
-	handler GossipHandler
+	topic     *pubsub.Topic
+	sub       *pubsub.Subscription
+	handler   GossipHandler
+	validator pubsub.Validator
 
 	logger log.Logger
 }

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -19,8 +19,8 @@ type GossipMessage struct {
 // GossipHandler is a callback function type.
 type GossipHandler func(*GossipMessage)
 
-// Gossip is an abstraction of P2P publish subscribe mechanism.
-type Gossip struct {
+// Gossiper is an abstraction of P2P publish subscribe mechanism.
+type Gossiper struct {
 	ownId peer.ID
 
 	topic   *pubsub.Topic
@@ -30,10 +30,10 @@ type Gossip struct {
 	logger log.Logger
 }
 
-// NewGossip creates new, ready to use instance of Gossip.
+// NewGossip creates new, ready to use instance of Gossiper.
 //
-// Returned Gossip object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
-func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger) (*Gossip, error) {
+// Returned Gossiper object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
+func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger) (*Gossiper, error) {
 	topic, err := ps.Join(topicStr)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Lo
 	if err != nil {
 		return nil, err
 	}
-	return &Gossip{
+	return &Gossiper{
 		ownId:   host.ID(),
 		topic:   topic,
 		sub:     subscription,
@@ -52,18 +52,18 @@ func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Lo
 	}, nil
 }
 
-func (g *Gossip) Close() error {
+func (g *Gossiper) Close() error {
 	g.sub.Cancel()
 	return g.topic.Close()
 }
 
 // Publish publishes data to gossip topic.
-func (g *Gossip) Publish(ctx context.Context, data []byte) error {
+func (g *Gossiper) Publish(ctx context.Context, data []byte) error {
 	return g.topic.Publish(ctx, data)
 }
 
 // ProcessMessages waits for messages published in the topic and execute handler.
-func (g *Gossip) ProcessMessages(ctx context.Context) {
+func (g *Gossiper) ProcessMessages(ctx context.Context) {
 	for {
 		msg, err := g.sub.Next(ctx)
 		if err != nil {

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"net"
 	"strings"
 	"testing"
@@ -109,7 +108,7 @@ func startTestNetwork(ctx context.Context, t *testing.T, n int, conf map[int]hos
 			logger)
 		require.NoError(err)
 		require.NotNil(client)
-		client.SetTxValidator(func(ctx context.Context, id peer.ID, message *pubsub.Message) bool {
+		client.SetTxValidator(func(_ *GossipMessage) bool {
 			// TODO(tzdybal): consider actually validating something here
 			return true
 		})

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"net"
 	"strings"
 	"testing"
@@ -108,6 +109,10 @@ func startTestNetwork(ctx context.Context, t *testing.T, n int, conf map[int]hos
 			logger)
 		require.NoError(err)
 		require.NotNil(client)
+		client.SetTxValidator(func(ctx context.Context, id peer.ID, message *pubsub.Message) bool {
+			// TODO(tzdybal): consider actually validating something here
+			return true
+		})
 
 		clients[i] = client
 	}

--- a/state/executor.go
+++ b/state/executor.go
@@ -17,7 +17,7 @@ import (
 	"github.com/celestiaorg/optimint/types"
 )
 
-// BlockExecutor creates and applies blocks and maintain state.
+// BlockExecutor creates and applies blocks and maintains state.
 type BlockExecutor struct {
 	proposerAddress []byte
 	namespaceID     [8]byte

--- a/types/block.go
+++ b/types/block.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding"
+
 // Header defines the structure of Optimint block header.
 type Header struct {
 	// Block and App version
@@ -33,6 +35,9 @@ type Header struct {
 	ProposerAddress []byte // original proposer of the block
 }
 
+var _ encoding.BinaryMarshaler = &Header{}
+var _ encoding.BinaryUnmarshaler = &Header{}
+
 // Version captures the consensus rules for processing a block in the blockchain,
 // including all blockchain data structures and the rules of the application's
 // state transition machine.
@@ -48,6 +53,9 @@ type Block struct {
 	Data       Data
 	LastCommit Commit
 }
+
+var _ encoding.BinaryMarshaler = &Block{}
+var _ encoding.BinaryUnmarshaler = &Block{}
 
 // Data defines Optimint block data.
 type Data struct {

--- a/types/serialization.go
+++ b/types/serialization.go
@@ -12,16 +12,6 @@ func (b *Block) MarshalBinary() ([]byte, error) {
 	return b.ToProto().Marshal()
 }
 
-// MarshalBinary encodes Header into binary form and returns it.
-func (h *Header) MarshalBinary() ([]byte, error) {
-	return h.ToProto().Marshal()
-}
-
-// MarshalBinary encodes Data into binary form and returns it.
-func (d *Data) MarshalBinary() ([]byte, error) {
-	return d.ToProto().Marshal()
-}
-
 // UnmarshalBinary decodes binary form of Block into object.
 func (b *Block) UnmarshalBinary(data []byte) error {
 	var pBlock pb.Block
@@ -31,6 +21,27 @@ func (b *Block) UnmarshalBinary(data []byte) error {
 	}
 	err = b.FromProto(&pBlock)
 	return err
+}
+
+// MarshalBinary encodes Header into binary form and returns it.
+func (h *Header) MarshalBinary() ([]byte, error) {
+	return h.ToProto().Marshal()
+}
+
+// UnmarshalBinary decodes binary form of Header into object.
+func (h *Header) UnmarshalBinary(data []byte) error {
+	var pHeader pb.Header
+	err := pHeader.Unmarshal(data)
+	if err != nil {
+		return err
+	}
+	err = h.FromProto(&pHeader)
+	return err
+}
+
+// MarshalBinary encodes Data into binary form and returns it.
+func (d *Data) MarshalBinary() ([]byte, error) {
+	return d.ToProto().Marshal()
 }
 
 // MarshalBinary encodes Commit into binary form and returns it.


### PR DESCRIPTION
This PR is limited to actual propagation (gossiping) of block headers and includes DALC client query for a block body.
Actual block processing and block synchronization will be addressed in follow-up PRs.

This PR takes changes from #97 a bit further. I introduced `GossipValidator` type to hide libp2p implementation details and clearly separate p2p layer. 