### PR TITLE
Extract gossiping logic into a type

### DIFF
--- a/node/aggregator_test.go
+++ b/node/aggregator_test.go
@@ -65,7 +65,7 @@ func TestAggregatorMode(t *testing.T) {
 			case <-ctx.Done():
 				return
 			default:
-				node.incomingTxCh <- &p2p.Tx{Data: []byte(time.Now().String()), From: pid}
+				node.incomingTxCh <- &p2p.GossipMessage{Data: []byte(time.Now().String()), From: pid}
 				time.Sleep(time.Duration(mrand.Uint32()%20) * time.Millisecond)
 			}
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -44,7 +44,7 @@ type Node struct {
 	// TODO(tzdybal): consider extracting "mempool reactor"
 	Mempool      mempool.Mempool
 	mempoolIDs   *mempoolIDs
-	incomingTxCh chan *p2p.Tx
+	incomingTxCh chan *p2p.GossipMessage
 
 	Store      store.Store
 	aggregator *aggregator
@@ -110,7 +110,7 @@ func NewNode(ctx context.Context, conf config.NodeConfig, nodeKey crypto.PrivKey
 		dalc:         dalc,
 		Mempool:      mp,
 		mempoolIDs:   newMempoolIDs(),
-		incomingTxCh: make(chan *p2p.Tx),
+		incomingTxCh: make(chan *p2p.GossipMessage),
 		Store:        store,
 		ctx:          ctx,
 	}
@@ -198,7 +198,7 @@ func (n *Node) OnStart() error {
 	if n.conf.Aggregator {
 		go n.aggregator.aggregationLoop(n.ctx)
 	}
-	n.P2P.SetTxHandler(func(tx *p2p.Tx) {
+	n.P2P.SetTxHandler(func(tx *p2p.GossipMessage) {
 		n.incomingTxCh <- tx
 	})
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -62,11 +62,11 @@ func TestMempoolDirectly(t *testing.T) {
 
 	pid, err := peer.IDFromPrivateKey(anotherKey)
 	require.NoError(err)
-	node.incomingTxCh <- &p2p.Tx{Data: []byte("tx1"), From: pid}
-	node.incomingTxCh <- &p2p.Tx{Data: []byte("tx2"), From: pid}
+	node.incomingTxCh <- &p2p.GossipMessage{Data: []byte("tx1"), From: pid}
+	node.incomingTxCh <- &p2p.GossipMessage{Data: []byte("tx2"), From: pid}
 	time.Sleep(100 * time.Millisecond)
-	node.incomingTxCh <- &p2p.Tx{Data: []byte("tx3"), From: pid}
-	node.incomingTxCh <- &p2p.Tx{Data: []byte("tx4"), From: pid}
+	node.incomingTxCh <- &p2p.GossipMessage{Data: []byte("tx3"), From: pid}
+	node.incomingTxCh <- &p2p.GossipMessage{Data: []byte("tx4"), From: pid}
 
 	time.Sleep(1 * time.Second)
 

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -34,15 +34,6 @@ const (
 	txTopicSuffix = "-tx"
 )
 
-// GossipMessage represents transaction gossiped via P2P network.
-type GossipMessage struct {
-	Data []byte
-	From peer.ID
-}
-
-// GossipHandler is a callback function type.
-type GossipHandler func(*GossipMessage)
-
 // Client is a P2P client, implemented with libp2p.
 //
 // Initially, client connects to predefined seed nodes (aka bootnodes, bootstrap nodes).
@@ -57,9 +48,7 @@ type Client struct {
 	dht  *dht.IpfsDHT
 	disc *discovery.RoutingDiscovery
 
-	txTopic   *pubsub.Topic
-	txSub     *pubsub.Subscription
-	txHandler GossipHandler
+	txGossip *Gossip
 
 	// cancel is used to cancel context passed to libp2p functions
 	// it's required because of discovery.Advertise call
@@ -137,7 +126,7 @@ func (c *Client) Close() error {
 	c.cancel()
 
 	return multierr.Combine(
-		c.txTopic.Close(),
+		c.txGossip.Close(),
 		c.dht.Close(),
 		c.host.Close(),
 	)
@@ -146,12 +135,12 @@ func (c *Client) Close() error {
 // GossipTx sends the transaction to the P2P network.
 func (c *Client) GossipTx(ctx context.Context, tx []byte) error {
 	c.logger.Debug("Gossiping TX", "len", len(tx))
-	return c.txTopic.Publish(ctx, tx)
+	return c.txGossip.Publish(ctx, tx)
 }
 
 // SetTxHandler sets the callback function, that will be invoked after transaction is received from P2P network.
 func (c *Client) SetTxHandler(handler GossipHandler) {
-	c.txHandler = handler
+	c.txGossip.handler = handler
 }
 
 func (c *Client) listen(ctx context.Context) (host.Host, error) {
@@ -256,37 +245,14 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	txTopic, err := ps.Join(c.getTxTopic())
+	c.txGossip, err = NewGossip(c.host, ps, c.getTxTopic(), c.logger)
 	if err != nil {
 		return err
 	}
-	c.txTopic = txTopic
-	txSub, err := txTopic.Subscribe()
-	if err != nil {
-		return err
-	}
-	c.txSub = txSub
 
-	go c.processTxs(ctx)
+	go c.txGossip.ProcessMessages(ctx)
 
 	return nil
-}
-
-func (c *Client) processTxs(ctx context.Context) {
-	for {
-		msg, err := c.txSub.Next(ctx)
-		if err != nil {
-			c.logger.Error("failed to read transaction", "error", err)
-			return
-		}
-		if msg.GetFrom() == c.host.ID() {
-			continue
-		}
-
-		if c.txHandler != nil {
-			c.txHandler(&GossipMessage{Data: msg.Data, From: msg.GetFrom()})
-		}
-	}
 }
 
 func (c *Client) getSeedAddrInfo(seedStr string) []peer.AddrInfo {

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -34,14 +34,14 @@ const (
 	txTopicSuffix = "-tx"
 )
 
-// Tx represents transaction gossiped via P2P network.
-type Tx struct {
+// GossipMessage represents transaction gossiped via P2P network.
+type GossipMessage struct {
 	Data []byte
 	From peer.ID
 }
 
-// TxHandler is a callback function type.
-type TxHandler func(*Tx)
+// GossipHandler is a callback function type.
+type GossipHandler func(*GossipMessage)
 
 // Client is a P2P client, implemented with libp2p.
 //
@@ -59,7 +59,7 @@ type Client struct {
 
 	txTopic   *pubsub.Topic
 	txSub     *pubsub.Subscription
-	txHandler TxHandler
+	txHandler GossipHandler
 
 	// cancel is used to cancel context passed to libp2p functions
 	// it's required because of discovery.Advertise call
@@ -150,7 +150,7 @@ func (c *Client) GossipTx(ctx context.Context, tx []byte) error {
 }
 
 // SetTxHandler sets the callback function, that will be invoked after transaction is received from P2P network.
-func (c *Client) SetTxHandler(handler TxHandler) {
+func (c *Client) SetTxHandler(handler GossipHandler) {
 	c.txHandler = handler
 }
 
@@ -284,7 +284,7 @@ func (c *Client) processTxs(ctx context.Context) {
 		}
 
 		if c.txHandler != nil {
-			c.txHandler(&Tx{Data: msg.Data, From: msg.GetFrom()})
+			c.txHandler(&GossipMessage{Data: msg.Data, From: msg.GetFrom()})
 		}
 	}
 }

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -96,7 +96,7 @@ func TestGossiping(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// ensure that Tx is delivered to client
-	assertRecv := func(tx *Tx) {
+	assertRecv := func(tx *GossipMessage) {
 		logger.Debug("received tx", "body", string(tx.Data))
 		assert.Equal(expectedMsg, tx.Data)
 		wg.Done()
@@ -106,7 +106,7 @@ func TestGossiping(t *testing.T) {
 	clients[3].SetTxHandler(assertRecv)
 
 	// ensure that Tx is not delivered to client
-	assertNotRecv := func(*Tx) {
+	assertNotRecv := func(*GossipMessage) {
 		t.Fatal("unexpected Tx received")
 	}
 	clients[1].SetTxHandler(assertNotRecv)

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -1,0 +1,79 @@
+package p2p
+
+import (
+	"context"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+
+	"github.com/lazyledger/optimint/log"
+)
+
+// GossipMessage represents transaction gossiped via P2P network.
+type GossipMessage struct {
+	Data []byte
+	From peer.ID
+}
+
+// GossipHandler is a callback function type.
+type GossipHandler func(*GossipMessage)
+
+// Gossip is an abstraction of P2P publish subscribe mechanism.
+type Gossip struct {
+	ownId peer.ID
+
+	topic   *pubsub.Topic
+	sub     *pubsub.Subscription
+	handler GossipHandler
+
+	logger log.Logger
+}
+
+// NewGossip create new, ready to use instance of Gossip.
+//
+// Returned Gossip object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
+func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger) (*Gossip, error) {
+	topic, err := ps.Join(topicStr)
+	if err != nil {
+		return nil, err
+	}
+	subscription, err := topic.Subscribe()
+	if err != nil {
+		return nil, err
+	}
+	return &Gossip{
+		ownId:   host.ID(),
+		topic:   topic,
+		sub:     subscription,
+		handler: nil,
+		logger:  logger,
+	}, nil
+}
+
+func (g *Gossip) Close() error {
+	g.sub.Cancel()
+	return g.topic.Close()
+}
+
+// Publish publishes data to gossip topic.
+func (g *Gossip) Publish(ctx context.Context, data []byte) error {
+	return g.topic.Publish(ctx, data)
+}
+
+// ProcessMessages waits for messages published in the topic and execute handler.
+func (g *Gossip) ProcessMessages(ctx context.Context) {
+	for {
+		msg, err := g.sub.Next(ctx)
+		if err != nil {
+			g.logger.Error("failed to read transaction", "error", err)
+			return
+		}
+		if msg.GetFrom() == g.ownId {
+			continue
+		}
+
+		if g.handler != nil {
+			g.handler(&GossipMessage{Data: msg.Data, From: msg.GetFrom()})
+		}
+	}
+}

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lazyledger/optimint/log"
 )
 
-// GossipMessage represents transaction gossiped via P2P network.
+// GossipMessage represents message gossiped via P2P network (e.g. transaction, Block etc).
 type GossipMessage struct {
 	Data []byte
 	From peer.ID
@@ -29,7 +29,7 @@ type Gossip struct {
 	logger log.Logger
 }
 
-// NewGossip create new, ready to use instance of Gossip.
+// NewGossip creates new, ready to use instance of Gossip.
 //
 // Returned Gossip object can be used for sending (Publishing) and receiving messages in topic identified by topicStr.
 func NewGossip(host host.Host, ps *pubsub.PubSub, topicStr string, logger log.Logger) (*Gossip, error) {


### PR DESCRIPTION
Rationale: this changes are extracted from #92. I made them, because gossiping is generic and I don't want to duplicate code for Txs, Blocks, Proofs, etc. Moreover, I think this abstraction is a good starting point for #93 - validator function could be added to `Gossip` struct.