### PR TITLE
On-disk storage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,8 @@ import "time"
 
 // NodeConfig stores Optimint node configuration.
 type NodeConfig struct {
+	RootDir    string
+	DBPath     string
 	P2P        P2PConfig
 	Aggregator bool
 	AggregatorConfig

--- a/conv/config.go
+++ b/conv/config.go
@@ -14,6 +14,8 @@ func GetNodeConfig(cfg *tmcfg.Config) config.NodeConfig {
 	nodeConf := config.NodeConfig{}
 
 	if cfg != nil {
+		nodeConf.RootDir = cfg.RootDir
+		nodeConf.DBPath = cfg.DBPath
 		if cfg.P2P != nil {
 			nodeConf.P2P.ListenAddress = cfg.P2P.ListenAddress
 			nodeConf.P2P.Seeds = cfg.P2P.Seeds

--- a/conv/config_test.go
+++ b/conv/config_test.go
@@ -20,6 +20,8 @@ func TestGetNodeConfig(t *testing.T) {
 		{"empty", nil, config.NodeConfig{}},
 		{"Seeds", &tmcfg.Config{P2P: &tmcfg.P2PConfig{Seeds: "seeds"}}, config.NodeConfig{P2P: config.P2PConfig{Seeds: "seeds"}}},
 		{"ListenAddress", &tmcfg.Config{P2P: &tmcfg.P2PConfig{ListenAddress: "127.0.0.1:7676"}}, config.NodeConfig{P2P: config.P2PConfig{ListenAddress: "127.0.0.1:7676"}}},
+		{"RootDir", &tmcfg.Config{BaseConfig: tmcfg.BaseConfig{RootDir: "~/root"}}, config.NodeConfig{RootDir: "~/root"}},
+		{"DBPath", &tmcfg.Config{BaseConfig: tmcfg.BaseConfig{DBPath: "./database"}}, config.NodeConfig{DBPath: "./database"}},
 	}
 
 	for _, c := range cases {

--- a/node/node.go
+++ b/node/node.go
@@ -76,8 +76,12 @@ func NewNode(ctx context.Context, conf config.NodeConfig, nodeKey crypto.PrivKey
 		return nil, err
 	}
 
-	// TODO(tzdybal): change after implementing https://github.com/celestiaorg/optimint/issues/67
-	baseKV := store.NewInMemoryKVStore()
+	var baseKV store.KVStore
+	if conf.RootDir == "" && conf.DBPath == "" { // this is used for testing
+		baseKV = store.NewInMemoryKVStore()
+	} else {
+		baseKV = store.NewKVStore(conf.RootDir, conf.DBPath, "optimint")
+	}
 	mainKV := store.NewPrefixKV(baseKV, mainPrefix)
 	dalcKV := store.NewPrefixKV(baseKV, dalcPrefix)
 

--- a/store/kv.go
+++ b/store/kv.go
@@ -1,6 +1,9 @@
 package store
 
-import "github.com/dgraph-io/badger/v3"
+import (
+	"github.com/dgraph-io/badger/v3"
+	"path/filepath"
+)
 
 // KVStore encapsulates key-value store abstraction, in minimalistic interface.
 //
@@ -20,4 +23,23 @@ func NewInMemoryKVStore() KVStore {
 	return &BadgerKV{
 		db: db,
 	}
+}
+
+func NewKVStore(rootDir, dbPath, dbName string) KVStore {
+	path := filepath.Join(rootify(rootDir, dbPath), dbName)
+	db, err := badger.Open(badger.DefaultOptions(path))
+	if err != nil {
+		panic(err)
+	}
+	return &BadgerKV{
+		db: db,
+	}
+}
+
+// rootify works just like in cosmos-sdk
+func rootify(rootDir, dbPath string) string {
+	if filepath.IsAbs(dbPath) {
+		return dbPath
+	}
+	return filepath.Join(rootDir, dbPath)
 }


### PR DESCRIPTION
For improved user/developer experience, configuration options "works" just like with plain cosmos-sdk/tendermint application (if `DBPath` is absolute, it is used as absolute path, otherwise it's rooted on `RootDir`).
After merging this PR, I'll update branches in cosmos-sdk to actually pass the `RootDir` and `DBPath` configuration params.

Resolves #67.