### PR TITLE
Block sync

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,13 +8,13 @@ type NodeConfig struct {
 	DBPath     string
 	P2P        P2PConfig
 	Aggregator bool
-	AggregatorConfig
+	BlockManagerConfig
 	DALayer  string
 	DAConfig []byte
 }
 
-// AggregatorConfig consists of all parameters required by Aggregator.
-type AggregatorConfig struct {
+// BlockManagerConfig consists of all parameters required by BlockManagerConfig
+type BlockManagerConfig struct {
 	BlockTime   time.Duration
 	NamespaceID [8]byte
 }

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"sync"
+
 	"github.com/celestiaorg/optimint/da"
 	"github.com/celestiaorg/optimint/log"
 	"github.com/celestiaorg/optimint/store"
@@ -14,6 +16,8 @@ type MockDataAvailabilityLayerClient struct {
 
 	Blocks     map[[32]byte]*types.Block
 	BlockIndex map[uint64][32]byte
+
+	mtx sync.Mutex
 }
 
 var _ da.DataAvailabilityLayerClient = &MockDataAvailabilityLayerClient{}
@@ -21,6 +25,8 @@ var _ da.BlockRetriever = &MockDataAvailabilityLayerClient{}
 
 // Init is called once to allow DA client to read configuration and initialize resources.
 func (m *MockDataAvailabilityLayerClient) Init(config []byte, kvStore store.KVStore, logger log.Logger) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	m.logger = logger
 	m.Blocks = make(map[[32]byte]*types.Block)
 	m.BlockIndex = make(map[uint64][32]byte)
@@ -43,6 +49,8 @@ func (m *MockDataAvailabilityLayerClient) Stop() error {
 // This should create a transaction which (potentially)
 // triggers a state transition in the DA layer.
 func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.ResultSubmitBlock {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	m.logger.Debug("Submitting block to DA layer!", "height", block.Header.Height)
 
 	hash := block.Header.Hash()
@@ -59,12 +67,19 @@ func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.Res
 
 // CheckBlockAvailability queries DA layer to check data availability of block corresponding to given header.
 func (m *MockDataAvailabilityLayerClient) CheckBlockAvailability(header *types.Header) da.ResultCheckBlock {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	_, ok := m.Blocks[header.Hash()]
 	return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, DataAvailable: ok}
 }
 
 // RetrieveBlock returns block at given height from data availability layer.
 func (m *MockDataAvailabilityLayerClient) RetrieveBlock(height uint64) da.ResultRetrieveBlock {
-	hash := m.BlockIndex[height]
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	hash, ok := m.BlockIndex[height]
+	if !ok {
+		return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError}}
+	}
 	return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, Block: m.Blocks[hash]}
 }


### PR DESCRIPTION
- [x] blocks passed to blockManager after gossiping
- [x] aggregator renamed to blockManager
- [x] DALC(BlockRetriever) used to fetch block data
- [ ] more refactoring (move `blockManager` out of `node` package)
- [ ] more tests
  - [ ] block propagation specific tests
  - [ ] more assertions in integration test 