### PR TITLE
Fix missed breaks in selects

### DIFF
--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -314,15 +314,21 @@ LOOP:
 	// Remove/reduce matches in filteredHashes that were not found in this
 	// match (tmpHashes).
 	for k := range filteredHeights {
+		cont := true
+
 		if tmpHeights[k] == nil {
 			delete(filteredHeights, k)
 
 			select {
 			case <-ctx.Done():
-				break
+				cont = false
 
 			default:
 			}
+		}
+
+		if !cont {
+			break
 		}
 	}
 
@@ -461,15 +467,21 @@ func (idx *BlockerIndexer) match(
 	// Remove/reduce matches in filteredHeights that were not found in this
 	// match (tmpHeights).
 	for k := range filteredHeights {
+		cont := true
+
 		if tmpHeights[k] == nil {
 			delete(filteredHeights, k)
 
 			select {
 			case <-ctx.Done():
-				break
+				cont = false
 
 			default:
 			}
+		}
+
+		if !cont {
+			break
 		}
 	}
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -426,15 +426,21 @@ func (txi *TxIndex) match(
 	// Remove/reduce matches in filteredHashes that were not found in this
 	// match (tmpHashes).
 	for k := range filteredHashes {
+		cont := true
+
 		if tmpHashes[k] == nil {
 			delete(filteredHashes, k)
 
 			// Potentially exit early.
 			select {
 			case <-ctx.Done():
-				break
+				cont = false
 			default:
 			}
+		}
+
+		if !cont {
+			break
 		}
 	}
 
@@ -533,15 +539,21 @@ LOOP:
 	// Remove/reduce matches in filteredHashes that were not found in this
 	// match (tmpHashes).
 	for k := range filteredHashes {
+		cont := true
+
 		if tmpHashes[k] == nil {
 			delete(filteredHashes, k)
 
 			// Potentially exit early.
 			select {
 			case <-ctx.Done():
-				break
+				cont = false
 			default:
 			}
+		}
+
+		if !cont {
+			break
 		}
 	}
 


### PR DESCRIPTION
For some reason _these were not caught_ by `staticcheck`. I manually noticed there were still `break`s inside of `select`s.