### PR TITLE
Replace tm-db dependency with store package

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -20,6 +20,7 @@ Month, DD, YYYY
 - [rpc] [Implement NumUnconfirmedTxs #255](https://github.com/celestiaorg/optimint/pull/255) [@tzdybal](https://github.com/tzdybal/)
 - [rpc] [Implement BlockByHash #256](https://github.com/celestiaorg/optimint/pull/256) [@mauriceLC92](https://github.com/mauriceLC92)
 - [rpc] [Implement BlockResults #263](https://github.com/celestiaorg/optimint/pull/263) [@tzdybal](https://github.com/tzdybal/)
+- [store,indexer] [Replace tm-db dependency with store package #268](https://github.com/celestiaorg/optimint/pull/268) [@tzdybal](https://github.com/tzdybal/)
 
 ### BUG FIXES
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.14
-	github.com/tendermint/tm-db v0.6.6
 	go.uber.org/multierr v1.7.0
 	golang.org/x/net v0.0.0-20211005001312-d4b1ae081e3b
 	google.golang.org/grpc v1.43.0
@@ -156,6 +155,7 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
+	github.com/tendermint/tm-db v0.6.6 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 
 	"github.com/google/orderedcode"
-	dbm "github.com/tendermint/tm-db"
 
-	"github.com/celestiaorg/optimint/state/indexer"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/optimint/state/indexer"
+	dbm "github.com/celestiaorg/optimint/store"
 )
 
 var _ indexer.BlockIndexer = (*BlockerIndexer)(nil)
@@ -23,10 +24,10 @@ var _ indexer.BlockIndexer = (*BlockerIndexer)(nil)
 // events with an underlying KV store. Block events are indexed by their height,
 // such that matching search criteria returns the respective block height(s).
 type BlockerIndexer struct {
-	store dbm.DB
+	store dbm.KVStore
 }
 
-func New(store dbm.DB) *BlockerIndexer {
+func New(store dbm.KVStore) *BlockerIndexer {
 	return &BlockerIndexer{
 		store: store,
 	}
@@ -40,7 +41,11 @@ func (idx *BlockerIndexer) Has(height int64) (bool, error) {
 		return false, fmt.Errorf("failed to create block height index key: %w", err)
 	}
 
-	return idx.store.Has(key)
+	_, err = idx.store.Get(key)
+	if err == dbm.ErrKeyNotFound {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 // Index indexes BeginBlock and EndBlock events for a given block by its height.
@@ -51,7 +56,7 @@ func (idx *BlockerIndexer) Has(height int64) (bool, error) {
 // EndBlock events: encode(eventType.eventAttr|eventValue|height|end_block) => encode(height)
 func (idx *BlockerIndexer) Index(bh types.EventDataNewBlockHeader) error {
 	batch := idx.store.NewBatch()
-	defer batch.Close()
+	defer batch.Discard()
 
 	height := bh.Header.Height
 
@@ -74,7 +79,7 @@ func (idx *BlockerIndexer) Index(bh types.EventDataNewBlockHeader) error {
 		return fmt.Errorf("failed to index EndBlock events: %w", err)
 	}
 
-	return batch.WriteSync()
+	return batch.Commit()
 }
 
 // Search performs a query for block heights that match a given BeginBlock

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -3,6 +3,7 @@ package kv_test
 import (
 	"context"
 	"fmt"
+	"github.com/celestiaorg/optimint/store"
 	"testing"
 
 	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
@@ -10,12 +11,11 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
-	db "github.com/tendermint/tm-db"
 )
 
 func TestBlockIndexer(t *testing.T) {
-	store := db.NewPrefixDB(db.NewMemDB(), []byte("block_events"))
-	indexer := blockidxkv.New(store)
+	prefixStore := store.NewPrefixKV(store.NewDefaultInMemoryKVStore(), []byte("block_events"))
+	indexer := blockidxkv.New(prefixStore)
 
 	require.NoError(t, indexer.Index(types.EventDataNewBlockHeader{
 		Header: types.Header{Height: 1},

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -3,14 +3,15 @@ package kv_test
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/optimint/store"
 	"testing"
 
-	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
+
+	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
+	"github.com/celestiaorg/optimint/store"
 )
 
 func TestBlockIndexer(t *testing.T) {

--- a/state/txindex/indexer_service_test.go
+++ b/state/txindex/indexer_service_test.go
@@ -1,17 +1,18 @@
 package txindex_test
 
 import (
-	"github.com/celestiaorg/optimint/store"
 	"testing"
 	"time"
 
-	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
-	"github.com/celestiaorg/optimint/state/txindex"
-	"github.com/celestiaorg/optimint/state/txindex/kv"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
+
+	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
+	"github.com/celestiaorg/optimint/state/txindex"
+	"github.com/celestiaorg/optimint/state/txindex/kv"
+	"github.com/celestiaorg/optimint/store"
 )
 
 func TestIndexerServiceIndexesBlocks(t *testing.T) {

--- a/state/txindex/indexer_service_test.go
+++ b/state/txindex/indexer_service_test.go
@@ -1,15 +1,14 @@
 package txindex_test
 
 import (
+	"github.com/celestiaorg/optimint/store"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
-	db "github.com/tendermint/tm-db"
 
 	blockidxkv "github.com/celestiaorg/optimint/state/indexer/block/kv"
 	"github.com/celestiaorg/optimint/state/txindex"
 	"github.com/celestiaorg/optimint/state/txindex/kv"
+	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
@@ -28,9 +27,9 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	})
 
 	// tx indexer
-	store := db.NewMemDB()
-	txIndexer := kv.NewTxIndex(store)
-	blockIndexer := blockidxkv.New(db.NewPrefixDB(store, []byte("block_events")))
+	kvStore := store.NewDefaultInMemoryKVStore()
+	txIndexer := kv.NewTxIndex(kvStore)
+	blockIndexer := blockidxkv.New(store.NewPrefixKV(kvStore, []byte("block_events")))
 
 	service := txindex.NewIndexerService(txIndexer, blockIndexer, eventBus)
 	service.SetLogger(log.TestingLogger())

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
-	dbm "github.com/tendermint/tm-db"
 
-	"github.com/celestiaorg/optimint/state/indexer"
-	"github.com/celestiaorg/optimint/state/txindex"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/optimint/state/indexer"
+	"github.com/celestiaorg/optimint/state/txindex"
+	dbm "github.com/celestiaorg/optimint/store"
 )
 
 const (
@@ -26,11 +27,11 @@ var _ txindex.TxIndexer = (*TxIndex)(nil)
 
 // TxIndex is the simplest possible indexer, backed by key-value storage (levelDB).
 type TxIndex struct {
-	store dbm.DB
+	store dbm.KVStore
 }
 
 // NewTxIndex creates new KV indexer.
-func NewTxIndex(store dbm.DB) *TxIndex {
+func NewTxIndex(store dbm.KVStore) *TxIndex {
 	return &TxIndex{
 		store: store,
 	}
@@ -66,7 +67,7 @@ func (txi *TxIndex) Get(hash []byte) (*abci.TxResult, error) {
 // Any event with an empty type is not indexed.
 func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 	storeBatch := txi.store.NewBatch()
-	defer storeBatch.Close()
+	defer storeBatch.Discard()
 
 	for _, result := range b.Ops {
 		hash := types.Tx(result.Tx).Hash()
@@ -94,7 +95,7 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 		}
 	}
 
-	return storeBatch.WriteSync()
+	return storeBatch.Commit()
 }
 
 // Index indexes a single transaction using the given list of events. Each key
@@ -103,7 +104,7 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 // Any event with an empty type is not indexed.
 func (txi *TxIndex) Index(result *abci.TxResult) error {
 	b := txi.store.NewBatch()
-	defer b.Close()
+	defer b.Discard()
 
 	hash := types.Tx(result.Tx).Hash()
 
@@ -129,7 +130,7 @@ func (txi *TxIndex) Index(result *abci.TxResult) error {
 		return err
 	}
 
-	return b.WriteSync()
+	return b.Commit()
 }
 
 func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Batch) error {

--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/celestiaorg/optimint/store"
 	"io/ioutil"
 	"testing"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/optimint/store"
 )
 
 func BenchmarkTxSearch(b *testing.B) {

--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"github.com/celestiaorg/optimint/store"
 	"io/ioutil"
 	"testing"
-
-	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
@@ -20,7 +19,7 @@ func BenchmarkTxSearch(b *testing.B) {
 		b.Errorf("failed to create temporary directory: %s", err)
 	}
 
-	db, err := dbm.NewGoLevelDB("benchmark_tx_search_test", dbDir)
+	db := store.NewDefaultKVStore(dbDir, "db", "benchmark_tx_search_test")
 	if err != nil {
 		b.Errorf("failed to create database: %s", err)
 	}

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"fmt"
-	"github.com/celestiaorg/optimint/store"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -12,11 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/optimint/state/txindex"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/types"
+
+	"github.com/celestiaorg/optimint/state/txindex"
+	"github.com/celestiaorg/optimint/store"
 )
 
 func TestTxIndex(t *testing.T) {

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"fmt"
+	"github.com/celestiaorg/optimint/store"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -10,8 +11,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	db "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/optimint/state/txindex"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -21,7 +20,7 @@ import (
 )
 
 func TestTxIndex(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	tx := types.Tx("HELLO WORLD")
 	txResult := &abci.TxResult{
@@ -67,7 +66,7 @@ func TestTxIndex(t *testing.T) {
 }
 
 func TestTxSearch(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("number"), Value: []byte("1"), Index: true}}},
@@ -141,7 +140,7 @@ func TestTxSearch(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("number"), Value: []byte("1"), Index: true}}},
@@ -159,7 +158,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 }
 
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	// index tx using events indexing (composite key)
 	txResult1 := txResultWithEvents([]abci.Event{
@@ -193,7 +192,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 	require.NoError(t, err)
 	err = b.Set(hash2, rawBytes)
 	require.NoError(t, err)
-	err = b.Write()
+	err = b.Commit()
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -238,7 +237,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("number"), Value: []byte("1"), Index: true}}},
@@ -260,7 +259,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(store.NewDefaultInMemoryKVStore())
 
 	// indexed first, but bigger height (to test the order of transactions)
 	txResult := txResultWithEvents([]abci.Event{
@@ -333,7 +332,7 @@ func benchmarkTxIndex(txsCount int64, b *testing.B) {
 	require.NoError(b, err)
 	defer os.RemoveAll(dir)
 
-	store, err := db.NewDB("tx_index", "goleveldb", dir)
+	store := store.NewDefaultKVStore(dir, "db", "tx_index")
 	require.NoError(b, err)
 	indexer := NewTxIndex(store)
 

--- a/store/kv.go
+++ b/store/kv.go
@@ -10,18 +10,29 @@ import (
 //
 // KVStore MUST be thread safe.
 type KVStore interface {
-	Get(key []byte) ([]byte, error)     // Get gets the value for a key.
-	Set(key []byte, value []byte) error // Set updates the value for a key.
-	Delete(key []byte) error            // Delete deletes a key.
-	NewBatch() Batch
+	Get(key []byte) ([]byte, error)        // Get gets the value for a key.
+	Set(key []byte, value []byte) error    // Set updates the value for a key.
+	Delete(key []byte) error               // Delete deletes a key.
+	NewBatch() Batch                       // NewBatch creates a new batch.
+	PrefixIterator(prefix []byte) Iterator // PrefixIterator creates iterator to traverse given prefix.
 }
 
-// Batch enables batching of transactions
+// Batch enables batching of transactions.
 type Batch interface {
-	Set(key, value []byte) error // Accumulates KV entries in a transaction
-	Delete(key []byte) error     // Deletes the given key
-	Commit() error               // Commits the transaction
-	Discard()                    // Discards the transaction
+	Set(key, value []byte) error // Accumulates KV entries in a transaction.
+	Delete(key []byte) error     // Deletes the given key.
+	Commit() error               // Commits the transaction.
+	Discard()                    // Discards the transaction.
+}
+
+// Iterator enables traversal over a given prefix.
+type Iterator interface {
+	Valid() bool
+	Next()
+	Key() []byte
+	Value() []byte
+	Error() error
+	Discard()
 }
 
 // NewInMemoryKVStore builds KVStore that works in-memory (without accessing disk).

--- a/store/prefix.go
+++ b/store/prefix.go
@@ -33,6 +33,10 @@ func (p *PrefixKV) NewBatch() Batch {
 	}
 }
 
+func (p *PrefixKV) PrefixIterator(prefix []byte) Iterator {
+	return p.kv.PrefixIterator(append(p.prefix, prefix...))
+}
+
 type PrefixKVBatch struct {
 	b      Batch
 	prefix []byte


### PR DESCRIPTION
* added prefix iterator support to `store`
* replaced tm-db dependency with `store` package in indexer
* bonus: indexer now use the same KV store instance as rest of optimint

Resolves #269