### PR TITLE
Implement BlockChainInfo RPC method

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -26,6 +26,7 @@ Month, DD, YYYY
 - [rpc] [Implement Tx Method #272](https://github.com/celestiaorg/optimint/pull/272) [@mauriceLC92](https://github.com/mauriceLC92)
 - [rpc] [Implement Commit and BlockSearch method #258](https://github.com/celestiaorg/optimint/pull/258) [@raneet10](https://github.com/Raneet10/)
 - [rpc] [Remove extra variable #280](https://github.com/celestiaorg/optimint/pull/280) [@raneet10](https://github.com/Raneet10/)
+- [rpc] [Implement BlockChainInfo RPC method #282](https://github.com/celestiaorg/optimint/pull/282) [@raneet10](https://github.com/Raneet10/)
 
 ### BUG FIXES
 

--- a/conv/abci/block.go
+++ b/conv/abci/block.go
@@ -98,6 +98,7 @@ func ToABCIBlock(block *types.Block) (*tmtypes.Block, error) {
 	return &abciBlock, nil
 }
 
+// ToABCIBlockMeta converts Optimint block into BlockMeta format defined by ABCI
 func ToABCIBlockMeta(block *types.Block) (*tmtypes.BlockMeta, error) {
 	tmblock, err := ToABCIBlock(block)
 	if err != nil {

--- a/conv/abci/block.go
+++ b/conv/abci/block.go
@@ -98,6 +98,21 @@ func ToABCIBlock(block *types.Block) (*tmtypes.Block, error) {
 	return &abciBlock, nil
 }
 
+func ToABCIBlockMeta(block *types.Block) (*tmtypes.BlockMeta, error) {
+	tmblock, err := ToABCIBlock(block)
+	if err != nil {
+		return nil, err
+	}
+	blockId := tmtypes.BlockID{Hash: tmblock.Hash()}
+
+	return &tmtypes.BlockMeta{
+		BlockID:   blockId,
+		BlockSize: tmblock.Size(),
+		Header:    tmblock.Header,
+		NumTxs:    len(tmblock.Txs),
+	}, nil
+}
+
 // ToABCICommit converts Optimint commit into commit format defined by ABCI.
 // This function only converts fields that are available in Optimint commit.
 // Other fields (especially ValidatorAddress and Timestamp of Signature) has to be filled by caller.

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -268,6 +268,8 @@ func (c *Client) GenesisChunked(context context.Context, id uint) (*ctypes.Resul
 
 func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
 	const limit int64 = 20
+
+	// Currently blocks are not pruned and are synced linearly so the base height is 0
 	minHeight, maxHeight, err := filterMinMax(
 		0,
 		int64(c.node.Store.Height()),

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -498,6 +498,10 @@ func TestConsensusState(t *testing.T) {
 	assert.ErrorIs(err, ErrConsensusStateNotAvailable)
 }
 
+func TestBlockchainInfo(t *testing.T) {
+	panic("todo")
+}
+
 // copy-pasted from store/store_test.go
 func getRandomBlock(height uint64, nTxs int) *types.Block {
 	block := &types.Block{

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/optimint/config"
+	abciconv "github.com/celestiaorg/optimint/conv/abci"
 	"github.com/celestiaorg/optimint/mocks"
 	"github.com/celestiaorg/optimint/node"
 	"github.com/celestiaorg/optimint/state"
@@ -499,7 +500,76 @@ func TestConsensusState(t *testing.T) {
 }
 
 func TestBlockchainInfo(t *testing.T) {
-	panic("todo")
+	require := require.New(t)
+	assert := assert.New(t)
+	mockApp, rpc := getRPC(t)
+	mockApp.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
+	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+
+	heights := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	for _, h := range heights {
+		block := getRandomBlock(uint64(h), 5)
+		err := rpc.node.Store.SaveBlock(block, &types.Commit{
+			Height:     uint64(h),
+			HeaderHash: block.Header.Hash(),
+		})
+		require.NoError(err)
+	}
+
+	tests := []struct {
+		desc string
+		min  int64
+		max  int64
+		exp  []*tmtypes.BlockMeta
+		err  bool
+	}{
+		{
+			desc: "min = 1 and max = 5",
+			min:  1,
+			max:  5,
+			exp:  []*tmtypes.BlockMeta{getBlockMeta(rpc, 1), getBlockMeta(rpc, 5)},
+			err:  false,
+		}, {
+			desc: "min height is 0",
+			min:  0,
+			max:  10,
+			exp:  []*tmtypes.BlockMeta{getBlockMeta(rpc, 1), getBlockMeta(rpc, 10)},
+			err:  false,
+		}, {
+			desc: "max height is out of range",
+			min:  0,
+			max:  15,
+			exp:  []*tmtypes.BlockMeta{getBlockMeta(rpc, 1), getBlockMeta(rpc, 10)},
+			err:  false,
+		}, {
+			desc: "negative min height",
+			min:  -1,
+			max:  11,
+			exp:  nil,
+			err:  true,
+		}, {
+			desc: "negative max height",
+			min:  1,
+			max:  -1,
+			exp:  nil,
+			err:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result, err := rpc.BlockchainInfo(context.Background(), test.min, test.max)
+			if test.err {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+				assert.Equal(result.LastHeight, heights[9])
+				assert.Contains(result.BlockMetas, test.exp[0])
+				assert.Contains(result.BlockMetas, test.exp[1])
+			}
+
+		})
+	}
 }
 
 // copy-pasted from store/store_test.go
@@ -548,6 +618,19 @@ func getRandomBytes(n int) []byte {
 	data := make([]byte, n)
 	_, _ = rand.Read(data)
 	return data
+}
+
+func getBlockMeta(rpc *Client, n int64) *tmtypes.BlockMeta {
+	b, err := rpc.node.Store.LoadBlock(uint64(n))
+	if err != nil {
+		return nil
+	}
+	bmeta, err := abciconv.ToABCIBlockMeta(b)
+	if err != nil {
+		return nil
+	}
+
+	return bmeta
 }
 
 func getRPC(t *testing.T) (*mocks.Application, *Client) {


### PR DESCRIPTION
This PR adds `BlockChainInfo` method for compatibility with Tendermint RPC

Implements #233 