### PR TITLE
fix: do save ABCI responses for blocks

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -31,5 +31,6 @@ Month, DD, YYYY
 ### BUG FIXES
 
 - [store] [Use KeyCopy instead of Key in BadgerIterator #274](https://github.com/celestiaorg/optimint/pull/274) [@tzdybal](https://github.com/tzdybal/)
+- [state/block] [Do save ABCI responses for blocks #285r](https://github.com/celestiaorg/optimint/pull/285) [@tzdybal](https://github.com/tzdybal/)
 
 - [go package] (Link to PR) Description @username

--- a/block/manager.go
+++ b/block/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) SyncLoop(ctx context.Context) {
 			b1, ok1 := m.syncCache[currentHeight+1]
 			b2, ok2 := m.syncCache[currentHeight+2]
 			if ok1 && ok2 {
-				newState, _, err := m.executor.ApplyBlock(ctx, m.lastState, b1)
+				newState, responses, _, err := m.executor.ApplyBlock(ctx, m.lastState, b1)
 				if err != nil {
 					m.logger.Error("failed to ApplyBlock", "error", err)
 					continue
@@ -173,6 +173,11 @@ func (m *Manager) SyncLoop(ctx context.Context) {
 				err = m.store.SaveBlock(b1, &b2.LastCommit)
 				if err != nil {
 					m.logger.Error("failed to save block", "error", err)
+					continue
+				}
+				err = m.store.SaveBlockResponses(block.Header.Height, responses)
+				if err != nil {
+					m.logger.Error("failed to save block responses", "error", err)
 					continue
 				}
 
@@ -271,7 +276,7 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 
 	block := m.executor.CreateBlock(newHeight, lastCommit, lastHeaderHash, m.lastState)
 	m.logger.Debug("block info", "num_tx", len(block.Data.Txs))
-	newState, _, err := m.executor.ApplyBlock(ctx, m.lastState, block)
+	newState, responses, _, err := m.executor.ApplyBlock(ctx, m.lastState, block)
 	if err != nil {
 		return err
 	}
@@ -291,6 +296,11 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 		Signatures: []types.Signature{sign},
 	}
 	err = m.store.SaveBlock(block, commit)
+	if err != nil {
+		return err
+	}
+
+	err = m.store.SaveBlockResponses(block.Header.Height, responses)
 	if err != nil {
 		return err
 	}

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -123,9 +123,10 @@ func TestApplyBlock(t *testing.T) {
 	assert.Equal(uint64(1), block.Header.Height)
 	assert.Len(block.Data.Txs, 1)
 
-	newState, _, err := executor.ApplyBlock(context.TODO(), state, block)
+	newState, resp, _, err := executor.ApplyBlock(context.Background(), state, block)
 	require.NoError(err)
 	require.NotNil(newState)
+	require.NotNil(resp)
 	assert.Equal(int64(1), newState.LastBlockHeight)
 	assert.Equal(mockAppHash, newState.AppHash)
 
@@ -138,9 +139,10 @@ func TestApplyBlock(t *testing.T) {
 	assert.Equal(uint64(2), block.Header.Height)
 	assert.Len(block.Data.Txs, 3)
 
-	newState, _, err = executor.ApplyBlock(context.TODO(), newState, block)
+	newState, resp, _, err = executor.ApplyBlock(context.Background(), newState, block)
 	require.NoError(err)
 	require.NotNil(newState)
+	require.NotNil(resp)
 	assert.Equal(int64(2), newState.LastBlockHeight)
 
 	// wait for at least 4 Tx events, for up to 3 second.


### PR DESCRIPTION
Resolves https://github.com/celestiaorg/optimint/issues/284.

I wanted to avoid introducing store to executor, so the responses are returned and saved in `BlockManager`.