### PR TITLE
fix: make `TestValidatorSetHandling` stable

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -38,5 +38,6 @@ Month, DD, YYYY
 - [conv/abci] [Map LastBlockID.Hash to LastHeaderHash in conversion #303](https://github.com/celestiaorg/optimint/pull/303) [@tzdybal](https://github.com/tzdybal/)
 - [chore] [Fix multiple bugs for Ethermint #305](https://github.com/celestiaorg/optimint/pull/305) [@tzdybal](https://github.com/tzdybal/)
 - [lint] [Fix linter on main #308](https://github.com/celestiaorg/optimint/pull/308) [@tzdybal](https://github.com/tzdybal/)
+- [rpc/client] [Make TestValidatorSetHandling stable](https://github.com/celestiaorg/optimint/pull/313) [@tzdybal](https://github.com/tzdybal/)
 
 - [go package] (Link to PR) Description @username

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -645,11 +645,15 @@ func TestValidatorSetHandling(t *testing.T) {
 	pbValKey, err := encoding.PubKeyToProto(vKeys[0].PubKey())
 	require.NoError(err)
 
+	waitCh := make(chan interface{})
+
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{}).Times(5)
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{{PubKey: pbValKey, Power: 0}}}).Once()
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{}).Once()
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{{PubKey: pbValKey, Power: 100}}}).Once()
-	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
+	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{}).Run(func(args mock.Arguments) {
+		waitCh <- nil
+	})
 
 	node, err := node.NewNode(context.Background(), config.NodeConfig{DALayer: "mock", Aggregator: true, BlockManagerConfig: config.BlockManagerConfig{BlockTime: 10 * time.Millisecond}}, key, proxy.NewLocalClientCreator(app), &tmtypes.GenesisDoc{ChainID: "test", Validators: genesisValidators}, log.TestingLogger())
 	require.NoError(err)
@@ -673,7 +677,7 @@ func TestValidatorSetHandling(t *testing.T) {
 		assert.Greater(vals.BlockHeight, lastHeight)
 		lastHeight = vals.BlockHeight
 	}
-	time.Sleep(100 * time.Millisecond)
+	<-waitCh
 
 	// 6th EndBlock removes first validator from the list
 	for h := int64(7); h <= 8; h++ {
@@ -687,6 +691,7 @@ func TestValidatorSetHandling(t *testing.T) {
 
 	// 8th EndBlock adds validator back
 	for h := int64(9); h < 12; h++ {
+		<-waitCh
 		vals, err := rpc.Validators(context.Background(), &h, nil, nil)
 		assert.NoError(err)
 		assert.NotNil(vals)


### PR DESCRIPTION
Instead of `time.Sleep` a channel is used for reliable synchronization

Resolves #293 