### PR TITLE
Comment out websocket handler

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -5,6 +5,7 @@
 ### BREAKING CHANGES
 
 - Add separate key for aggregator signatures ([#309](https://github.com/celestiaorg/optimint/pull/309)) [@mauriceLC92](https://github.com/mauriceLC92)
+- Comment out the websocket handler ([#318](https://github.com/celestiaorg/optimint/pull/318)) [@jbowen93](https://github.com/jbowen93)
 
 ### FEATURES
 

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -32,7 +32,7 @@ func newHandler(s *service, codec rpc.Codec, logger log.Logger) *handler {
 	}
 
 	mux.HandleFunc("/", h.serveJSONRPC)
-	mux.HandleFunc("/websocket", h.wsHandler)
+	// mux.HandleFunc("/websocket", h.wsHandler)
 	for name, method := range s.methods {
 		logger.Debug("registering method", "name", name)
 		mux.HandleFunc("/"+name, h.newHandler(method))


### PR DESCRIPTION
The websocket handler isn't working and pollutes the logs. We should comment it out on the main branch until it's in a better state. 