### PR TITLE
New DALC API

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -229,10 +229,12 @@ func (m *Manager) mustRetrieveBlock(ctx context.Context, height uint64) {
 
 func (m *Manager) fetchBlock(ctx context.Context, height uint64) error {
 	var err error
-	blockRes := m.retriever.RetrieveBlock(height)
+	blockRes := m.retriever.RetrieveBlocks(height)
 	switch blockRes.Code {
 	case da.StatusSuccess:
-		m.blockInCh <- blockRes.Block
+		for _, block := range blockRes.Blocks {
+			m.blockInCh <- block
+		}
 	case da.StatusError:
 		err = fmt.Errorf("failed to retrieve block: %s", blockRes.Message)
 	case da.StatusTimeout:

--- a/block/manager.go
+++ b/block/manager.go
@@ -41,7 +41,8 @@ type Manager struct {
 
 	dalc      da.DataAvailabilityLayerClient
 	retriever da.BlockRetriever
-	daHeight  uint64 // height of the latest processed DA block
+	// daHeight is the height of the latest processed DA block
+	daHeight uint64
 
 	HeaderOutCh chan *types.Header
 	HeaderInCh  chan *types.Header

--- a/block/manager.go
+++ b/block/manager.go
@@ -3,7 +3,6 @@ package block
 import (
 	"context"
 	"fmt"
-	"go.uber.org/multierr"
 	"sync/atomic"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/proxy"
 	tmtypes "github.com/tendermint/tendermint/types"
+	"go.uber.org/multierr"
 
 	"github.com/celestiaorg/optimint/config"
 	"github.com/celestiaorg/optimint/da"

--- a/block/manager.go
+++ b/block/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/celestiaorg/optimint/types"
 )
 
+// defaultDABlockTime is used only if DABlockTime is not configured for manager
 const defaultDABlockTime = 30 * time.Second
 
 // Manager is responsible for aggregating transactions into blocks.
@@ -212,7 +213,6 @@ func (m *Manager) SyncLoop(ctx context.Context) {
 				delete(m.syncCache, currentHeight+1)
 			}
 		case <-ctx.Done():
-			m.logger.Debug("exiting SyncLoop")
 			return
 		}
 	}

--- a/block/manager.go
+++ b/block/manager.go
@@ -83,6 +83,9 @@ func NewManager(
 	if err != nil {
 		return nil, err
 	}
+	if s.DAHeight < conf.DAStartHeight {
+		s.DAHeight = conf.DAStartHeight
+	}
 
 	proposerAddress, err := getAddress(proposerKey)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,9 @@ type BlockManagerConfig struct {
 	BlockTime time.Duration `mapstructure:"block_time"`
 	// DABlockTime informs about block time of underlying data availability layer
 	DABlockTime time.Duration `mapstructure:"da_block_time"`
-	NamespaceID [8]byte       `mapstructure:"namespace_id"`
+	// DAStartHeight allows skipping first DAStartHeight-1 blocks when querying for blocks.
+	DAStartHeight uint64  `mapstructure:"da_start_height"`
+	NamespaceID   [8]byte `mapstructure:"namespace_id"`
 }
 
 func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,9 @@ type NodeConfig struct {
 
 // BlockManagerConfig consists of all parameters required by BlockManagerConfig
 type BlockManagerConfig struct {
-	BlockTime   time.Duration `mapstructure:"block_time"`
+	// BlockTime defines how often new blocks are produced
+	BlockTime time.Duration `mapstructure:"block_time"`
+	// DABlockTime informs about block time of underlying data availability layer
 	DABlockTime time.Duration `mapstructure:"da_block_time"`
 	NamespaceID [8]byte       `mapstructure:"namespace_id"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type NodeConfig struct {
 // BlockManagerConfig consists of all parameters required by BlockManagerConfig
 type BlockManagerConfig struct {
 	BlockTime   time.Duration `mapstructure:"block_time"`
+	DABlockTime time.Duration `mapstructure:"da_block_time"`
 	NamespaceID [8]byte       `mapstructure:"namespace_id"`
 }
 

--- a/da/da.go
+++ b/da/da.go
@@ -25,6 +25,8 @@ type DAResult struct {
 	Code StatusCode
 	// Message may contain DA layer specific information (like DA block height/hash, detailed error message, etc)
 	Message string
+	// DataLayerHeight informs about a height on Data Availability Layer for given result.
+	DataLayerHeight uint64
 }
 
 // ResultSubmitBlock contains information returned from DA layer after block submission.
@@ -47,7 +49,7 @@ type ResultRetrieveBlock struct {
 	DAResult
 	// Block is the full block retrieved from Data Availability Layer.
 	// If Code is not equal to StatusSuccess, it has to be nil.
-	Block *types.Block
+	Blocks []*types.Block
 }
 
 // DataAvailabilityLayerClient defines generic interface for DA layer block submission.
@@ -65,12 +67,12 @@ type DataAvailabilityLayerClient interface {
 	SubmitBlock(block *types.Block) ResultSubmitBlock
 
 	// CheckBlockAvailability queries DA layer to check data availability of block corresponding to given header.
-	CheckBlockAvailability(header *types.Header) ResultCheckBlock
+	CheckBlockAvailability(dataLayerHeight uint64) ResultCheckBlock
 }
 
 // BlockRetriever is additional interface that can be implemented by Data Availability Layer Client that is able to retrieve
 // block data from DA layer. This gives the ability to use it for block synchronization.
 type BlockRetriever interface {
-	// RetrieveBlock returns block at given height from data availability layer.
-	RetrieveBlock(height uint64) ResultRetrieveBlock
+	// RetrieveBlocks returns blocks at given data layer height from data availability layer.
+	RetrieveBlocks(dataLayerHeight uint64) ResultRetrieveBlock
 }

--- a/da/da.go
+++ b/da/da.go
@@ -45,7 +45,7 @@ type ResultCheckBlock struct {
 	DataAvailable bool
 }
 
-type ResultRetrieveBlock struct {
+type ResultRetrieveBlocks struct {
 	DAResult
 	// Block is the full block retrieved from Data Availability Layer.
 	// If Code is not equal to StatusSuccess, it has to be nil.
@@ -74,5 +74,5 @@ type DataAvailabilityLayerClient interface {
 // block data from DA layer. This gives the ability to use it for block synchronization.
 type BlockRetriever interface {
 	// RetrieveBlocks returns blocks at given data layer height from data availability layer.
-	RetrieveBlocks(dataLayerHeight uint64) ResultRetrieveBlock
+	RetrieveBlocks(dataLayerHeight uint64) ResultRetrieveBlocks
 }

--- a/da/da.go
+++ b/da/da.go
@@ -25,8 +25,8 @@ type DAResult struct {
 	Code StatusCode
 	// Message may contain DA layer specific information (like DA block height/hash, detailed error message, etc)
 	Message string
-	// DataLayerHeight informs about a height on Data Availability Layer for given result.
-	DataLayerHeight uint64
+	// DAHeight informs about a height on Data Availability Layer for given result.
+	DAHeight uint64
 }
 
 // ResultSubmitBlock contains information returned from DA layer after block submission.

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -110,7 +110,11 @@ func (d *DataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.
 		blocks[i] = &b
 	}
 	return da.ResultRetrieveBlock{
-		DAResult: da.DAResult{Code: da.StatusCode(resp.Result.Code), Message: resp.Result.Message},
-		Blocks:   blocks,
+		DAResult: da.DAResult{
+			Code:            da.StatusCode(resp.Result.Code),
+			Message:         resp.Result.Message,
+			DataLayerHeight: dataLayerHeight,
+		},
+		Blocks: blocks,
 	}
 }

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -76,9 +76,9 @@ func (d *DataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.ResultS
 	}
 	return da.ResultSubmitBlock{
 		DAResult: da.DAResult{
-			Code:            da.StatusCode(resp.Result.Code),
-			Message:         resp.Result.Message,
-			DataLayerHeight: resp.Result.DataLayerHeight,
+			Code:     da.StatusCode(resp.Result.Code),
+			Message:  resp.Result.Message,
+			DAHeight: resp.Result.DataLayerHeight,
 		},
 	}
 }
@@ -111,9 +111,9 @@ func (d *DataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.
 	}
 	return da.ResultRetrieveBlocks{
 		DAResult: da.DAResult{
-			Code:            da.StatusCode(resp.Result.Code),
-			Message:         resp.Result.Message,
-			DataLayerHeight: dataLayerHeight,
+			Code:     da.StatusCode(resp.Result.Code),
+			Message:  resp.Result.Message,
+			DAHeight: dataLayerHeight,
 		},
 		Blocks: blocks,
 	}

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -94,10 +94,10 @@ func (d *DataAvailabilityLayerClient) CheckBlockAvailability(dataLayerHeight uin
 	}
 }
 
-func (d *DataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.ResultRetrieveBlock {
+func (d *DataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.ResultRetrieveBlocks {
 	resp, err := d.client.RetrieveBlocks(context.TODO(), &dalc.RetrieveBlocksRequest{DataLayerHeight: dataLayerHeight})
 	if err != nil {
-		return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
+		return da.ResultRetrieveBlocks{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
 	}
 
 	blocks := make([]*types.Block, len(resp.Blocks))
@@ -105,11 +105,11 @@ func (d *DataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.
 		var b types.Block
 		err = b.FromProto(block)
 		if err != nil {
-			return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
+			return da.ResultRetrieveBlocks{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
 		}
 		blocks[i] = &b
 	}
-	return da.ResultRetrieveBlock{
+	return da.ResultRetrieveBlocks{
 		DAResult: da.DAResult{
 			Code:            da.StatusCode(resp.Result.Code),
 			Message:         resp.Result.Message,

--- a/da/grpc/mockserv/cmd/main.go
+++ b/da/grpc/mockserv/cmd/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Panic(err)
 	}
 	log.Println("Listening on:", lis.Addr())
-	srv := mockserv.GetServer(kv, conf)
+	srv := mockserv.GetServer(kv, conf, nil)
 	if err := srv.Serve(lis); err != nil {
 		log.Println("error while serving:", err)
 	}

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"os"
 
+	tmlog "github.com/tendermint/tendermint/libs/log"
+	"google.golang.org/grpc"
+
 	grpcda "github.com/celestiaorg/optimint/da/grpc"
 	"github.com/celestiaorg/optimint/da/mock"
 	"github.com/celestiaorg/optimint/store"
 	"github.com/celestiaorg/optimint/types"
 	"github.com/celestiaorg/optimint/types/pb/dalc"
-	tmlog "github.com/tendermint/tendermint/libs/log"
-	"google.golang.org/grpc"
+	"github.com/celestiaorg/optimint/types/pb/optimint"
 )
 
 func GetServer(kv store.KVStore, conf grpcda.Config) *grpc.Server {
@@ -40,19 +42,15 @@ func (m *mockImpl) SubmitBlock(_ context.Context, request *dalc.SubmitBlockReque
 	resp := m.mock.SubmitBlock(&b)
 	return &dalc.SubmitBlockResponse{
 		Result: &dalc.DAResponse{
-			Code:    dalc.StatusCode(resp.Code),
-			Message: resp.Message,
+			Code:            dalc.StatusCode(resp.Code),
+			Message:         resp.Message,
+			DataLayerHeight: resp.DataLayerHeight,
 		},
 	}, nil
 }
 
 func (m *mockImpl) CheckBlockAvailability(_ context.Context, request *dalc.CheckBlockAvailabilityRequest) (*dalc.CheckBlockAvailabilityResponse, error) {
-	var h types.Header
-	err := h.FromProto(request.Header)
-	if err != nil {
-		return nil, err
-	}
-	resp := m.mock.CheckBlockAvailability(&h)
+	resp := m.mock.CheckBlockAvailability(request.DataLayerHeight)
 	return &dalc.CheckBlockAvailabilityResponse{
 		Result: &dalc.DAResponse{
 			Code:    dalc.StatusCode(resp.Code),
@@ -62,13 +60,17 @@ func (m *mockImpl) CheckBlockAvailability(_ context.Context, request *dalc.Check
 	}, nil
 }
 
-func (m *mockImpl) RetrieveBlock(context context.Context, request *dalc.RetrieveBlockRequest) (*dalc.RetrieveBlockResponse, error) {
-	resp := m.mock.RetrieveBlock(request.Height)
-	return &dalc.RetrieveBlockResponse{
+func (m *mockImpl) RetrieveBlocks(context context.Context, request *dalc.RetrieveBlocksRequest) (*dalc.RetrieveBlocksResponse, error) {
+	resp := m.mock.RetrieveBlocks(request.DataLayerHeight)
+	blocks := make([]*optimint.Block, len(resp.Blocks))
+	for i := range resp.Blocks {
+		blocks[i] = resp.Blocks[i].ToProto()
+	}
+	return &dalc.RetrieveBlocksResponse{
 		Result: &dalc.DAResponse{
 			Code:    dalc.StatusCode(resp.Code),
 			Message: resp.Message,
 		},
-		Block: resp.Block.ToProto(),
+		Blocks: blocks,
 	}, nil
 }

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -49,7 +49,7 @@ func (m *mockImpl) SubmitBlock(_ context.Context, request *dalc.SubmitBlockReque
 		Result: &dalc.DAResponse{
 			Code:            dalc.StatusCode(resp.Code),
 			Message:         resp.Message,
-			DataLayerHeight: resp.DataLayerHeight,
+			DataLayerHeight: resp.DAHeight,
 		},
 	}, nil
 }

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -15,14 +15,19 @@ import (
 	"github.com/celestiaorg/optimint/types/pb/optimint"
 )
 
-func GetServer(kv store.KVStore, conf grpcda.Config) *grpc.Server {
+func GetServer(kv store.KVStore, conf grpcda.Config, mockConfig []byte) *grpc.Server {
 	logger := tmlog.NewTMLogger(os.Stdout)
 
 	srv := grpc.NewServer()
 	mockImpl := &mockImpl{}
-	err := mockImpl.mock.Init(nil, kv, logger)
+	err := mockImpl.mock.Init(mockConfig, kv, logger)
 	if err != nil {
 		logger.Error("failed to initialize mock DALC", "error", err)
+		panic(err)
+	}
+	err = mockImpl.mock.Start()
+	if err != nil {
+		logger.Error("failed to start mock DALC", "error", err)
 		panic(err)
 	}
 	dalc.RegisterDALCServiceServer(srv, mockImpl)

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -2,7 +2,7 @@ package mock
 
 import (
 	"encoding/binary"
-	"errors"
+	"math/rand"
 	"sync/atomic"
 
 	"github.com/celestiaorg/optimint/da"
@@ -26,6 +26,7 @@ var _ da.BlockRetriever = &MockDataAvailabilityLayerClient{}
 func (m *MockDataAvailabilityLayerClient) Init(config []byte, dalcKV store.KVStore, logger log.Logger) error {
 	m.logger = logger
 	m.dalcKV = dalcKV
+	m.daHeight = 1
 	return nil
 }
 
@@ -45,8 +46,8 @@ func (m *MockDataAvailabilityLayerClient) Stop() error {
 // This should create a transaction which (potentially)
 // triggers a state transition in the DA layer.
 func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.ResultSubmitBlock {
-	height := atomic.AddUint64(&m.daHeight, 1)
-	m.logger.Debug("Submitting block to DA layer!", "height", block.Header.Height, "dataLayerHeight", height)
+	daHeight := m.updateDAHeight()
+	m.logger.Debug("Submitting block to DA layer!", "height", block.Header.Height, "dataLayerHeight", daHeight)
 
 	hash := block.Header.Hash()
 	blob, err := block.MarshalBinary()
@@ -54,8 +55,7 @@ func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.Res
 		return da.ResultSubmitBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
 	}
 
-	// TODO(tzdybal): more than one optimint block per "mock" DA height
-	err = m.dalcKV.Set(getKey(height), hash[:])
+	err = m.dalcKV.Set(getKey(daHeight, block.Header.Height), hash[:])
 	if err != nil {
 		return da.ResultSubmitBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
 	}
@@ -68,52 +68,64 @@ func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.Res
 		DAResult: da.DAResult{
 			Code:            da.StatusSuccess,
 			Message:         "OK",
-			DataLayerHeight: height,
+			DataLayerHeight: daHeight,
 		},
 	}
 }
 
 // CheckBlockAvailability queries DA layer to check data availability of block corresponding to given header.
 func (m *MockDataAvailabilityLayerClient) CheckBlockAvailability(dataLayerHeight uint64) da.ResultCheckBlock {
-	hash, err := m.dalcKV.Get(getKey(dataLayerHeight))
-	if errors.Is(err, store.ErrKeyNotFound) {
-		return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, DataAvailable: false}
-	}
-	if err != nil {
-		return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}, DataAvailable: false}
-	}
-	_, err = m.dalcKV.Get(hash[:])
-	if errors.Is(err, store.ErrKeyNotFound) {
-		return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, DataAvailable: false}
-	}
-	if err != nil {
-		return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}, DataAvailable: false}
-	}
-	return da.ResultCheckBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, DataAvailable: true}
+	blocksRes := m.RetrieveBlocks(dataLayerHeight)
+	return da.ResultCheckBlock{DAResult: da.DAResult{Code: blocksRes.Code}, DataAvailable: len(blocksRes.Blocks) > 0}
 }
 
 // RetrieveBlocks returns block at given height from data availability layer.
 func (m *MockDataAvailabilityLayerClient) RetrieveBlocks(dataLayerHeight uint64) da.ResultRetrieveBlock {
-	hash, err := m.dalcKV.Get(getKey(dataLayerHeight))
-	if err != nil {
-		return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
-	}
-	blob, err := m.dalcKV.Get(hash)
-	if err != nil {
-		return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
+	iter := m.dalcKV.PrefixIterator(getPrefix(dataLayerHeight))
+	defer iter.Discard()
+
+	var blocks []*types.Block
+	for iter.Valid() {
+		hash := iter.Value()
+
+		blob, err := m.dalcKV.Get(hash)
+		if err != nil {
+			return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
+		}
+
+		block := &types.Block{}
+		err = block.UnmarshalBinary(blob)
+		if err != nil {
+			return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
+		}
+		blocks = append(blocks, block)
+
+		iter.Next()
 	}
 
-	block := &types.Block{}
-	err = block.UnmarshalBinary(blob)
-	if err != nil {
-		return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusError, Message: err.Error()}}
-	}
-
-	return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, Blocks: []*types.Block{block}}
+	return da.ResultRetrieveBlock{DAResult: da.DAResult{Code: da.StatusSuccess}, Blocks: blocks}
 }
 
-func getKey(height uint64) []byte {
+func getPrefix(daHeight uint64) []byte {
 	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, height)
+	binary.BigEndian.PutUint64(b, daHeight)
 	return b
+}
+
+func getKey(daHeight uint64, height uint64) []byte {
+	b := make([]byte, 16)
+	binary.BigEndian.PutUint64(b, daHeight)
+	binary.BigEndian.PutUint64(b[8:], height)
+	return b
+}
+
+func (m *MockDataAvailabilityLayerClient) updateDAHeight() uint64 {
+	// add between 1 and 10 "DA blocks", every 4 optimint blocks (on average)
+	// this is mock. numbers are arbitrary
+	blockStep := uint64(0)
+	if rand.Uint64()%4 == 0 {
+		blockStep = rand.Uint64()%10 + 1
+	}
+	height := atomic.AddUint64(&m.daHeight, blockStep)
+	return height
 }

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -89,9 +89,9 @@ func (m *MockDataAvailabilityLayerClient) SubmitBlock(block *types.Block) da.Res
 
 	return da.ResultSubmitBlock{
 		DAResult: da.DAResult{
-			Code:            da.StatusSuccess,
-			Message:         "OK",
-			DataLayerHeight: daHeight,
+			Code:     da.StatusSuccess,
+			Message:  "OK",
+			DAHeight: daHeight,
 		},
 	}
 }

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -136,7 +136,7 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 		ret := retriever.RetrieveBlocks(resp.DataLayerHeight)
 		assert.Equal(da.StatusSuccess, ret.Code)
 		require.NotEmpty(ret.Blocks)
-		assert.Equal(b, ret.Blocks[0])
+		assert.Contains(ret.Blocks, b)
 	}
 }
 

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -79,11 +79,11 @@ func doTestDALC(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	b2 := getRandomBlock(2, 10)
 
 	resp := dalc.SubmitBlock(b1)
-	h1 := resp.DataLayerHeight
+	h1 := resp.DAHeight
 	assert.Equal(da.StatusSuccess, resp.Code)
 
 	resp = dalc.SubmitBlock(b2)
-	h2 := resp.DataLayerHeight
+	h2 := resp.DAHeight
 	assert.Equal(da.StatusSuccess, resp.Code)
 
 	// wait a bit more than mockDaBlockTime, so optimint blocks can be "included" in mock block
@@ -158,8 +158,8 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 		assert.Equal(da.StatusSuccess, resp.Code)
 		time.Sleep(time.Duration(rand.Int63() % mockDaBlockTime.Milliseconds()))
 
-		countAtHeight[resp.DataLayerHeight]++
-		blocks[b] = resp.DataLayerHeight
+		countAtHeight[resp.DAHeight]++
+		blocks[b] = resp.DAHeight
 	}
 
 	// wait a bit more than mockDaBlockTime, so mock can "produce" last blocks

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -36,7 +36,7 @@ func TestLifecycle(t *testing.T) {
 func doTestLifecycle(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	require := require.New(t)
 
-	err := dalc.Init([]byte{}, nil, &test.TestLogger{T: t})
+	err := dalc.Init([]byte{}, nil, test.NewTestLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -65,7 +65,7 @@ func doTestDALC(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	if _, ok := dalc.(*mock.MockDataAvailabilityLayerClient); ok {
 		conf = []byte(mockDaBlockTime.String())
 	}
-	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), &test.TestLogger{T: t})
+	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), test.NewTestLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -139,7 +139,7 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	if _, ok := dalc.(*mock.MockDataAvailabilityLayerClient); ok {
 		conf = []byte(mockDaBlockTime.String())
 	}
-	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), &test.TestLogger{T: t})
+	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), test.NewTestLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -1,11 +1,6 @@
 package test
 
 import (
-	grpcda "github.com/celestiaorg/optimint/da/grpc"
-	"github.com/celestiaorg/optimint/da/grpc/mockserv"
-	"github.com/celestiaorg/optimint/da/mock"
-	"github.com/celestiaorg/optimint/store"
-	"google.golang.org/grpc"
 	"math/rand"
 	"net"
 	"strconv"
@@ -14,10 +9,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/celestiaorg/optimint/da"
+	grpcda "github.com/celestiaorg/optimint/da/grpc"
+	"github.com/celestiaorg/optimint/da/grpc/mockserv"
+	"github.com/celestiaorg/optimint/da/mock"
 	"github.com/celestiaorg/optimint/da/registry"
 	"github.com/celestiaorg/optimint/log/test"
+	"github.com/celestiaorg/optimint/store"
 	"github.com/celestiaorg/optimint/types"
 )
 

--- a/log/test/loggers.go
+++ b/log/test/loggers.go
@@ -8,8 +8,15 @@ import (
 
 // TODO(tzdybal): move to some common place
 type TestLogger struct {
-	mtx sync.Mutex
+	mtx *sync.Mutex
 	T   *testing.T
+}
+
+func NewTestLogger(t *testing.T) *TestLogger {
+	return &TestLogger{
+		mtx: new(sync.Mutex),
+		T:   t,
+	}
 }
 
 func (t *TestLogger) Debug(msg string, keyvals ...interface{}) {

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -103,7 +103,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 		require.NoError(nodes[i].P2P.GossipTx(context.TODO(), []byte(data)))
 	}
 
-	timeout := time.NewTimer(time.Second * 5)
+	timeout := time.NewTimer(time.Second * 30)
 	doneChan := make(chan struct{})
 	go func() {
 		defer close(doneChan)

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestClientStartup(t *testing.T) {
 	privKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	client, err := NewClient(config.P2PConfig{}, privKey, "TestChain", &test.TestLogger{T: t})
+	client, err := NewClient(config.P2PConfig{}, privKey, "TestChain", test.NewTestLogger(t))
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.NotNil(client)
@@ -35,7 +35,7 @@ func TestBootstrapping(t *testing.T) {
 	//log.SetDebugLogging()
 
 	assert := assert.New(t)
-	logger := &test.TestLogger{T: t}
+	logger := test.NewTestLogger(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -55,7 +55,7 @@ func TestBootstrapping(t *testing.T) {
 
 func TestDiscovery(t *testing.T) {
 	assert := assert.New(t)
-	logger := &test.TestLogger{T: t}
+	logger := test.NewTestLogger(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -75,7 +75,7 @@ func TestDiscovery(t *testing.T) {
 
 func TestGossiping(t *testing.T) {
 	assert := assert.New(t)
-	logger := &test.TestLogger{T: t}
+	logger := test.NewTestLogger(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/proto/dalc/dalc.proto
+++ b/proto/dalc/dalc.proto
@@ -14,6 +14,7 @@ enum StatusCode {
 message DAResponse {
 	StatusCode code = 1;
 	string message = 2;
+	uint64 data_layer_height = 3;
 }
 
 message SubmitBlockRequest {
@@ -25,7 +26,7 @@ message SubmitBlockResponse {
 }
 
 message CheckBlockAvailabilityRequest {
-	optimint.Header header = 1;
+	uint64 data_layer_height = 1;
 }
 
 message CheckBlockAvailabilityResponse {
@@ -33,17 +34,17 @@ message CheckBlockAvailabilityResponse {
 	bool data_available = 2;
 }
 
-message RetrieveBlockRequest {
-	uint64 height = 1;
+message RetrieveBlocksRequest {
+	uint64 data_layer_height = 1;
 }
 
-message RetrieveBlockResponse {
+message RetrieveBlocksResponse {
 	DAResponse result = 1;
-	optimint.Block block = 2;
+	repeated optimint.Block blocks = 2;
 }
 
 service DALCService {
 	rpc SubmitBlock(SubmitBlockRequest) returns (SubmitBlockResponse) {}
 	rpc CheckBlockAvailability(CheckBlockAvailabilityRequest) returns (CheckBlockAvailabilityResponse) {}
-	rpc RetrieveBlock(RetrieveBlockRequest) returns (RetrieveBlockResponse) {}
+	rpc RetrieveBlocks(RetrieveBlocksRequest) returns (RetrieveBlocksResponse) {}
 }

--- a/state/state.go
+++ b/state/state.go
@@ -37,6 +37,8 @@ type State struct {
 	LastBlockID     types.BlockID
 	LastBlockTime   time.Time
 
+	DAHeight uint64
+
 	// In the MVP implementation, there will be only one Validator
 	NextValidators              *types.ValidatorSet
 	Validators                  *types.ValidatorSet
@@ -79,6 +81,8 @@ func NewFromGenesisDoc(genDoc *types.GenesisDoc) (State, error) {
 		Version:       InitStateVersion,
 		ChainID:       genDoc.ChainID,
 		InitialHeight: genDoc.InitialHeight,
+
+		DAHeight: 1,
 
 		LastBlockHeight: 0,
 		LastBlockID:     types.BlockID{},

--- a/types/pb/dalc/dalc.pb.go
+++ b/types/pb/dalc/dalc.pb.go
@@ -13,8 +13,8 @@
 		SubmitBlockResponse
 		CheckBlockAvailabilityRequest
 		CheckBlockAvailabilityResponse
-		RetrieveBlockRequest
-		RetrieveBlockResponse
+		RetrieveBlocksRequest
+		RetrieveBlocksResponse
 */
 package dalc
 
@@ -69,8 +69,9 @@ func (x StatusCode) String() string {
 func (StatusCode) EnumDescriptor() ([]byte, []int) { return fileDescriptorDalc, []int{0} }
 
 type DAResponse struct {
-	Code    StatusCode `protobuf:"varint,1,opt,name=code,proto3,enum=dalc.StatusCode" json:"code,omitempty"`
-	Message string     `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Code            StatusCode `protobuf:"varint,1,opt,name=code,proto3,enum=dalc.StatusCode" json:"code,omitempty"`
+	Message         string     `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	DataLayerHeight uint64     `protobuf:"varint,3,opt,name=data_layer_height,json=dataLayerHeight,proto3" json:"data_layer_height,omitempty"`
 }
 
 func (m *DAResponse) Reset()                    { *m = DAResponse{} }
@@ -90,6 +91,13 @@ func (m *DAResponse) GetMessage() string {
 		return m.Message
 	}
 	return ""
+}
+
+func (m *DAResponse) GetDataLayerHeight() uint64 {
+	if m != nil {
+		return m.DataLayerHeight
+	}
+	return 0
 }
 
 type SubmitBlockRequest struct {
@@ -125,7 +133,7 @@ func (m *SubmitBlockResponse) GetResult() *DAResponse {
 }
 
 type CheckBlockAvailabilityRequest struct {
-	Header *optimint.Header `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	DataLayerHeight uint64 `protobuf:"varint,1,opt,name=data_layer_height,json=dataLayerHeight,proto3" json:"data_layer_height,omitempty"`
 }
 
 func (m *CheckBlockAvailabilityRequest) Reset()         { *m = CheckBlockAvailabilityRequest{} }
@@ -135,11 +143,11 @@ func (*CheckBlockAvailabilityRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptorDalc, []int{3}
 }
 
-func (m *CheckBlockAvailabilityRequest) GetHeader() *optimint.Header {
+func (m *CheckBlockAvailabilityRequest) GetDataLayerHeight() uint64 {
 	if m != nil {
-		return m.Header
+		return m.DataLayerHeight
 	}
-	return nil
+	return 0
 }
 
 type CheckBlockAvailabilityResponse struct {
@@ -168,42 +176,42 @@ func (m *CheckBlockAvailabilityResponse) GetDataAvailable() bool {
 	return false
 }
 
-type RetrieveBlockRequest struct {
-	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
+type RetrieveBlocksRequest struct {
+	DataLayerHeight uint64 `protobuf:"varint,1,opt,name=data_layer_height,json=dataLayerHeight,proto3" json:"data_layer_height,omitempty"`
 }
 
-func (m *RetrieveBlockRequest) Reset()                    { *m = RetrieveBlockRequest{} }
-func (m *RetrieveBlockRequest) String() string            { return proto.CompactTextString(m) }
-func (*RetrieveBlockRequest) ProtoMessage()               {}
-func (*RetrieveBlockRequest) Descriptor() ([]byte, []int) { return fileDescriptorDalc, []int{5} }
+func (m *RetrieveBlocksRequest) Reset()                    { *m = RetrieveBlocksRequest{} }
+func (m *RetrieveBlocksRequest) String() string            { return proto.CompactTextString(m) }
+func (*RetrieveBlocksRequest) ProtoMessage()               {}
+func (*RetrieveBlocksRequest) Descriptor() ([]byte, []int) { return fileDescriptorDalc, []int{5} }
 
-func (m *RetrieveBlockRequest) GetHeight() uint64 {
+func (m *RetrieveBlocksRequest) GetDataLayerHeight() uint64 {
 	if m != nil {
-		return m.Height
+		return m.DataLayerHeight
 	}
 	return 0
 }
 
-type RetrieveBlockResponse struct {
-	Result *DAResponse     `protobuf:"bytes,1,opt,name=result" json:"result,omitempty"`
-	Block  *optimint.Block `protobuf:"bytes,2,opt,name=block" json:"block,omitempty"`
+type RetrieveBlocksResponse struct {
+	Result *DAResponse       `protobuf:"bytes,1,opt,name=result" json:"result,omitempty"`
+	Blocks []*optimint.Block `protobuf:"bytes,2,rep,name=blocks" json:"blocks,omitempty"`
 }
 
-func (m *RetrieveBlockResponse) Reset()                    { *m = RetrieveBlockResponse{} }
-func (m *RetrieveBlockResponse) String() string            { return proto.CompactTextString(m) }
-func (*RetrieveBlockResponse) ProtoMessage()               {}
-func (*RetrieveBlockResponse) Descriptor() ([]byte, []int) { return fileDescriptorDalc, []int{6} }
+func (m *RetrieveBlocksResponse) Reset()                    { *m = RetrieveBlocksResponse{} }
+func (m *RetrieveBlocksResponse) String() string            { return proto.CompactTextString(m) }
+func (*RetrieveBlocksResponse) ProtoMessage()               {}
+func (*RetrieveBlocksResponse) Descriptor() ([]byte, []int) { return fileDescriptorDalc, []int{6} }
 
-func (m *RetrieveBlockResponse) GetResult() *DAResponse {
+func (m *RetrieveBlocksResponse) GetResult() *DAResponse {
 	if m != nil {
 		return m.Result
 	}
 	return nil
 }
 
-func (m *RetrieveBlockResponse) GetBlock() *optimint.Block {
+func (m *RetrieveBlocksResponse) GetBlocks() []*optimint.Block {
 	if m != nil {
-		return m.Block
+		return m.Blocks
 	}
 	return nil
 }
@@ -214,8 +222,8 @@ func init() {
 	proto.RegisterType((*SubmitBlockResponse)(nil), "dalc.SubmitBlockResponse")
 	proto.RegisterType((*CheckBlockAvailabilityRequest)(nil), "dalc.CheckBlockAvailabilityRequest")
 	proto.RegisterType((*CheckBlockAvailabilityResponse)(nil), "dalc.CheckBlockAvailabilityResponse")
-	proto.RegisterType((*RetrieveBlockRequest)(nil), "dalc.RetrieveBlockRequest")
-	proto.RegisterType((*RetrieveBlockResponse)(nil), "dalc.RetrieveBlockResponse")
+	proto.RegisterType((*RetrieveBlocksRequest)(nil), "dalc.RetrieveBlocksRequest")
+	proto.RegisterType((*RetrieveBlocksResponse)(nil), "dalc.RetrieveBlocksResponse")
 	proto.RegisterEnum("dalc.StatusCode", StatusCode_name, StatusCode_value)
 }
 
@@ -232,7 +240,7 @@ const _ = grpc.SupportPackageIsVersion4
 type DALCServiceClient interface {
 	SubmitBlock(ctx context.Context, in *SubmitBlockRequest, opts ...grpc.CallOption) (*SubmitBlockResponse, error)
 	CheckBlockAvailability(ctx context.Context, in *CheckBlockAvailabilityRequest, opts ...grpc.CallOption) (*CheckBlockAvailabilityResponse, error)
-	RetrieveBlock(ctx context.Context, in *RetrieveBlockRequest, opts ...grpc.CallOption) (*RetrieveBlockResponse, error)
+	RetrieveBlocks(ctx context.Context, in *RetrieveBlocksRequest, opts ...grpc.CallOption) (*RetrieveBlocksResponse, error)
 }
 
 type dALCServiceClient struct {
@@ -261,9 +269,9 @@ func (c *dALCServiceClient) CheckBlockAvailability(ctx context.Context, in *Chec
 	return out, nil
 }
 
-func (c *dALCServiceClient) RetrieveBlock(ctx context.Context, in *RetrieveBlockRequest, opts ...grpc.CallOption) (*RetrieveBlockResponse, error) {
-	out := new(RetrieveBlockResponse)
-	err := grpc.Invoke(ctx, "/dalc.DALCService/RetrieveBlock", in, out, c.cc, opts...)
+func (c *dALCServiceClient) RetrieveBlocks(ctx context.Context, in *RetrieveBlocksRequest, opts ...grpc.CallOption) (*RetrieveBlocksResponse, error) {
+	out := new(RetrieveBlocksResponse)
+	err := grpc.Invoke(ctx, "/dalc.DALCService/RetrieveBlocks", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +283,7 @@ func (c *dALCServiceClient) RetrieveBlock(ctx context.Context, in *RetrieveBlock
 type DALCServiceServer interface {
 	SubmitBlock(context.Context, *SubmitBlockRequest) (*SubmitBlockResponse, error)
 	CheckBlockAvailability(context.Context, *CheckBlockAvailabilityRequest) (*CheckBlockAvailabilityResponse, error)
-	RetrieveBlock(context.Context, *RetrieveBlockRequest) (*RetrieveBlockResponse, error)
+	RetrieveBlocks(context.Context, *RetrieveBlocksRequest) (*RetrieveBlocksResponse, error)
 }
 
 func RegisterDALCServiceServer(s *grpc.Server, srv DALCServiceServer) {
@@ -318,20 +326,20 @@ func _DALCService_CheckBlockAvailability_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DALCService_RetrieveBlock_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RetrieveBlockRequest)
+func _DALCService_RetrieveBlocks_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RetrieveBlocksRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DALCServiceServer).RetrieveBlock(ctx, in)
+		return srv.(DALCServiceServer).RetrieveBlocks(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/dalc.DALCService/RetrieveBlock",
+		FullMethod: "/dalc.DALCService/RetrieveBlocks",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DALCServiceServer).RetrieveBlock(ctx, req.(*RetrieveBlockRequest))
+		return srv.(DALCServiceServer).RetrieveBlocks(ctx, req.(*RetrieveBlocksRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -349,8 +357,8 @@ var _DALCService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DALCService_CheckBlockAvailability_Handler,
 		},
 		{
-			MethodName: "RetrieveBlock",
-			Handler:    _DALCService_RetrieveBlock_Handler,
+			MethodName: "RetrieveBlocks",
+			Handler:    _DALCService_RetrieveBlocks_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -382,6 +390,11 @@ func (m *DAResponse) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintDalc(dAtA, i, uint64(len(m.Message)))
 		i += copy(dAtA[i:], m.Message)
+	}
+	if m.DataLayerHeight != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintDalc(dAtA, i, uint64(m.DataLayerHeight))
 	}
 	return i, nil
 }
@@ -457,15 +470,10 @@ func (m *CheckBlockAvailabilityRequest) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.Header != nil {
-		dAtA[i] = 0xa
+	if m.DataLayerHeight != 0 {
+		dAtA[i] = 0x8
 		i++
-		i = encodeVarintDalc(dAtA, i, uint64(m.Header.Size()))
-		n3, err := m.Header.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
+		i = encodeVarintDalc(dAtA, i, uint64(m.DataLayerHeight))
 	}
 	return i, nil
 }
@@ -489,11 +497,11 @@ func (m *CheckBlockAvailabilityResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintDalc(dAtA, i, uint64(m.Result.Size()))
-		n4, err := m.Result.MarshalTo(dAtA[i:])
+		n3, err := m.Result.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n3
 	}
 	if m.DataAvailable {
 		dAtA[i] = 0x10
@@ -508,7 +516,7 @@ func (m *CheckBlockAvailabilityResponse) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func (m *RetrieveBlockRequest) Marshal() (dAtA []byte, err error) {
+func (m *RetrieveBlocksRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -518,20 +526,20 @@ func (m *RetrieveBlockRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *RetrieveBlockRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *RetrieveBlocksRequest) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
 	_ = l
-	if m.Height != 0 {
+	if m.DataLayerHeight != 0 {
 		dAtA[i] = 0x8
 		i++
-		i = encodeVarintDalc(dAtA, i, uint64(m.Height))
+		i = encodeVarintDalc(dAtA, i, uint64(m.DataLayerHeight))
 	}
 	return i, nil
 }
 
-func (m *RetrieveBlockResponse) Marshal() (dAtA []byte, err error) {
+func (m *RetrieveBlocksResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -541,7 +549,7 @@ func (m *RetrieveBlockResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *RetrieveBlockResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *RetrieveBlocksResponse) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -550,21 +558,23 @@ func (m *RetrieveBlockResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintDalc(dAtA, i, uint64(m.Result.Size()))
-		n5, err := m.Result.MarshalTo(dAtA[i:])
+		n4, err := m.Result.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n4
 	}
-	if m.Block != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintDalc(dAtA, i, uint64(m.Block.Size()))
-		n6, err := m.Block.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	if len(m.Blocks) > 0 {
+		for _, msg := range m.Blocks {
+			dAtA[i] = 0x12
+			i++
+			i = encodeVarintDalc(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
-		i += n6
 	}
 	return i, nil
 }
@@ -606,6 +616,9 @@ func (m *DAResponse) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovDalc(uint64(l))
 	}
+	if m.DataLayerHeight != 0 {
+		n += 1 + sovDalc(uint64(m.DataLayerHeight))
+	}
 	return n
 }
 
@@ -632,9 +645,8 @@ func (m *SubmitBlockResponse) Size() (n int) {
 func (m *CheckBlockAvailabilityRequest) Size() (n int) {
 	var l int
 	_ = l
-	if m.Header != nil {
-		l = m.Header.Size()
-		n += 1 + l + sovDalc(uint64(l))
+	if m.DataLayerHeight != 0 {
+		n += 1 + sovDalc(uint64(m.DataLayerHeight))
 	}
 	return n
 }
@@ -652,25 +664,27 @@ func (m *CheckBlockAvailabilityResponse) Size() (n int) {
 	return n
 }
 
-func (m *RetrieveBlockRequest) Size() (n int) {
+func (m *RetrieveBlocksRequest) Size() (n int) {
 	var l int
 	_ = l
-	if m.Height != 0 {
-		n += 1 + sovDalc(uint64(m.Height))
+	if m.DataLayerHeight != 0 {
+		n += 1 + sovDalc(uint64(m.DataLayerHeight))
 	}
 	return n
 }
 
-func (m *RetrieveBlockResponse) Size() (n int) {
+func (m *RetrieveBlocksResponse) Size() (n int) {
 	var l int
 	_ = l
 	if m.Result != nil {
 		l = m.Result.Size()
 		n += 1 + l + sovDalc(uint64(l))
 	}
-	if m.Block != nil {
-		l = m.Block.Size()
-		n += 1 + l + sovDalc(uint64(l))
+	if len(m.Blocks) > 0 {
+		for _, e := range m.Blocks {
+			l = e.Size()
+			n += 1 + l + sovDalc(uint64(l))
+		}
 	}
 	return n
 }
@@ -765,6 +779,25 @@ func (m *DAResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Message = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataLayerHeight", wireType)
+			}
+			m.DataLayerHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDalc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DataLayerHeight |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDalc(dAtA[iNdEx:])
@@ -982,10 +1015,10 @@ func (m *CheckBlockAvailabilityRequest) Unmarshal(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Header", wireType)
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataLayerHeight", wireType)
 			}
-			var msglen int
+			m.DataLayerHeight = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowDalc
@@ -995,25 +1028,11 @@ func (m *CheckBlockAvailabilityRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				m.DataLayerHeight |= (uint64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			if msglen < 0 {
-				return ErrInvalidLengthDalc
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Header == nil {
-				m.Header = &optimint.Header{}
-			}
-			if err := m.Header.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDalc(dAtA[iNdEx:])
@@ -1138,7 +1157,7 @@ func (m *CheckBlockAvailabilityResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *RetrieveBlockRequest) Unmarshal(dAtA []byte) error {
+func (m *RetrieveBlocksRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1161,17 +1180,17 @@ func (m *RetrieveBlockRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: RetrieveBlockRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: RetrieveBlocksRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RetrieveBlockRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: RetrieveBlocksRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Height", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DataLayerHeight", wireType)
 			}
-			m.Height = 0
+			m.DataLayerHeight = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowDalc
@@ -1181,7 +1200,7 @@ func (m *RetrieveBlockRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Height |= (uint64(b) & 0x7F) << shift
+				m.DataLayerHeight |= (uint64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1207,7 +1226,7 @@ func (m *RetrieveBlockRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *RetrieveBlockResponse) Unmarshal(dAtA []byte) error {
+func (m *RetrieveBlocksResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1230,10 +1249,10 @@ func (m *RetrieveBlockResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: RetrieveBlockResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: RetrieveBlocksResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RetrieveBlockResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: RetrieveBlocksResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -1271,7 +1290,7 @@ func (m *RetrieveBlockResponse) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Block", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Blocks", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1295,10 +1314,8 @@ func (m *RetrieveBlockResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Block == nil {
-				m.Block = &optimint.Block{}
-			}
-			if err := m.Block.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.Blocks = append(m.Blocks, &optimint.Block{})
+			if err := m.Blocks[len(m.Blocks)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1431,37 +1448,38 @@ var (
 func init() { proto.RegisterFile("dalc/dalc.proto", fileDescriptorDalc) }
 
 var fileDescriptorDalc = []byte{
-	// 501 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0xcd, 0x6e, 0xd3, 0x40,
-	0x10, 0xae, 0x43, 0x08, 0x30, 0x51, 0xdb, 0xb0, 0xa5, 0x4d, 0x48, 0x45, 0x54, 0x99, 0x56, 0x8a,
-	0x90, 0xb0, 0xa5, 0x70, 0xe4, 0x50, 0xb9, 0xb6, 0x11, 0x41, 0x85, 0xa0, 0x75, 0x72, 0xe1, 0x12,
-	0xad, 0xed, 0x51, 0xbc, 0xaa, 0x53, 0xbb, 0xf6, 0x3a, 0x52, 0x5f, 0x80, 0x67, 0xe0, 0x91, 0x38,
-	0xf2, 0x08, 0x28, 0xbc, 0x08, 0xf2, 0x6f, 0x93, 0x12, 0x22, 0xc1, 0xc5, 0xda, 0x99, 0x6f, 0xe6,
-	0xdb, 0xcf, 0x3b, 0xdf, 0x2e, 0xec, 0xbb, 0xcc, 0x77, 0xd4, 0xf4, 0xa3, 0x84, 0x51, 0x20, 0x02,
-	0x52, 0x4f, 0xd7, 0xdd, 0x76, 0x10, 0x0a, 0x3e, 0xe7, 0xd7, 0x42, 0x2d, 0x17, 0x39, 0x2c, 0x5f,
-	0x02, 0x18, 0x1a, 0xc5, 0x38, 0x0c, 0xae, 0x63, 0x24, 0xa7, 0x50, 0x77, 0x02, 0x17, 0x3b, 0xd2,
-	0x89, 0xd4, 0xdf, 0x1b, 0xb4, 0x94, 0x8c, 0xc7, 0x12, 0x4c, 0x24, 0xb1, 0x1e, 0xb8, 0x48, 0x33,
-	0x94, 0x74, 0xe0, 0xd1, 0x1c, 0xe3, 0x98, 0xcd, 0xb0, 0x53, 0x3b, 0x91, 0xfa, 0x4f, 0x68, 0x19,
-	0xca, 0x6f, 0x81, 0x58, 0x89, 0x3d, 0xe7, 0xe2, 0xc2, 0x0f, 0x9c, 0x2b, 0x8a, 0x37, 0x09, 0xc6,
-	0x82, 0x9c, 0xc1, 0x43, 0x3b, 0x8d, 0x33, 0xda, 0xe6, 0x60, 0x5f, 0xa9, 0x34, 0xe4, 0x65, 0x39,
-	0x2a, 0x9f, 0xc3, 0xc1, 0x5a, 0x73, 0xa1, 0xa9, 0x0f, 0x8d, 0x08, 0xe3, 0xc4, 0x17, 0x45, 0x7b,
-	0xa1, 0xea, 0x4e, 0x35, 0x2d, 0x70, 0x79, 0x08, 0x2f, 0x74, 0x0f, 0x9d, 0xab, 0xac, 0x5f, 0x5b,
-	0x30, 0xee, 0x33, 0x9b, 0xfb, 0x5c, 0xdc, 0x96, 0x42, 0xfa, 0xd0, 0xf0, 0x90, 0xb9, 0x18, 0x55,
-	0x54, 0x95, 0x92, 0xf7, 0x59, 0x9e, 0x16, 0xb8, 0x7c, 0x03, 0xbd, 0xbf, 0x51, 0xfd, 0xab, 0x2c,
-	0x72, 0x06, 0x7b, 0x2e, 0x13, 0x6c, 0xca, 0x72, 0x1a, 0x3f, 0x3f, 0xb5, 0xc7, 0x74, 0x37, 0xcd,
-	0x6a, 0x65, 0x52, 0x56, 0xe0, 0x19, 0x45, 0x11, 0x71, 0x5c, 0xe0, 0xda, 0xe9, 0x1d, 0xa5, 0xa2,
-	0xf9, 0xcc, 0xcb, 0x37, 0xaa, 0xd3, 0x22, 0x92, 0x3d, 0x38, 0xbc, 0x57, 0xff, 0x1f, 0xca, 0x8a,
-	0xc1, 0xd4, 0xb6, 0x0d, 0xe6, 0x55, 0x04, 0x70, 0xe7, 0x01, 0x72, 0x0c, 0x6d, 0x6b, 0xac, 0x8d,
-	0x27, 0xd6, 0x54, 0x1f, 0x19, 0xe6, 0x74, 0xf2, 0xc9, 0xfa, 0x6c, 0xea, 0xc3, 0x77, 0x43, 0xd3,
-	0x68, 0xed, 0x90, 0x36, 0x1c, 0xac, 0x82, 0xd6, 0x44, 0xd7, 0x4d, 0xcb, 0x6a, 0x49, 0xf7, 0x81,
-	0xf1, 0xf0, 0xa3, 0x39, 0x9a, 0x8c, 0x5b, 0x35, 0x72, 0x08, 0x4f, 0x57, 0x01, 0x93, 0xd2, 0x11,
-	0x6d, 0x3d, 0x18, 0x7c, 0xad, 0x41, 0xd3, 0xd0, 0x2e, 0x75, 0x0b, 0xa3, 0x05, 0x77, 0x90, 0x18,
-	0xd0, 0x5c, 0x31, 0x07, 0xe9, 0x14, 0xd6, 0xfc, 0xc3, 0x6c, 0xdd, 0xe7, 0x1b, 0x90, 0xfc, 0xb7,
-	0xe5, 0x1d, 0x82, 0x70, 0xb4, 0x79, 0xac, 0xe4, 0x65, 0xde, 0xb6, 0xd5, 0x3f, 0xdd, 0xd3, 0xed,
-	0x45, 0xd5, 0x36, 0x1f, 0x60, 0x77, 0x6d, 0x34, 0xa4, 0x9b, 0x37, 0x6e, 0x9a, 0x6f, 0xf7, 0x78,
-	0x23, 0x56, 0x72, 0x5d, 0x9c, 0x7f, 0x5f, 0xf6, 0xa4, 0x1f, 0xcb, 0x9e, 0xf4, 0x73, 0xd9, 0x93,
-	0xbe, 0xfd, 0xea, 0xed, 0x7c, 0x79, 0x3d, 0xe3, 0xc2, 0x4b, 0x6c, 0xc5, 0x09, 0xe6, 0xaa, 0x83,
-	0x3e, 0xc6, 0x82, 0xb3, 0x20, 0x9a, 0x55, 0x37, 0x5b, 0x15, 0xb7, 0x21, 0xc6, 0x6a, 0x68, 0x67,
-	0xcf, 0x80, 0xdd, 0xc8, 0x2e, 0xfa, 0x9b, 0xdf, 0x01, 0x00, 0x00, 0xff, 0xff, 0xb9, 0xb4, 0x5b,
-	0xe6, 0x1a, 0x04, 0x00, 0x00,
+	// 518 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x94, 0x51, 0x6f, 0x12, 0x41,
+	0x10, 0xc7, 0x39, 0x40, 0xd4, 0x21, 0x02, 0xdd, 0xa6, 0xe5, 0xa4, 0x4a, 0xc8, 0xd9, 0x46, 0xd2,
+	0x44, 0x48, 0xf0, 0xd1, 0x87, 0x86, 0x1e, 0x67, 0x24, 0xb6, 0x62, 0xf6, 0xe0, 0xc5, 0x17, 0xb2,
+	0x77, 0x4c, 0x60, 0xc3, 0xd1, 0xa3, 0xb7, 0x0b, 0x91, 0x8f, 0xe0, 0x37, 0xf0, 0x23, 0xf9, 0xe8,
+	0x47, 0x30, 0xf8, 0x45, 0xcc, 0xed, 0x1d, 0x94, 0xd6, 0xb3, 0x49, 0x7d, 0xb9, 0xec, 0xce, 0x6f,
+	0x67, 0xe6, 0x3f, 0x37, 0x93, 0x81, 0xe2, 0x88, 0x79, 0x6e, 0x33, 0xfc, 0x34, 0xe6, 0x81, 0x2f,
+	0x7d, 0x92, 0x0d, 0xcf, 0x95, 0xb2, 0x3f, 0x97, 0x7c, 0xc6, 0xaf, 0x64, 0x73, 0x73, 0x88, 0xb0,
+	0xf1, 0x15, 0xa0, 0xd3, 0xa6, 0x28, 0xe6, 0xfe, 0x95, 0x40, 0x72, 0x0c, 0x59, 0xd7, 0x1f, 0xa1,
+	0xae, 0xd5, 0xb4, 0x7a, 0xa1, 0x55, 0x6a, 0xa8, 0x38, 0xb6, 0x64, 0x72, 0x21, 0x4c, 0x7f, 0x84,
+	0x54, 0x51, 0xa2, 0xc3, 0xe3, 0x19, 0x0a, 0xc1, 0xc6, 0xa8, 0xa7, 0x6b, 0x5a, 0xfd, 0x29, 0xdd,
+	0x5c, 0xc9, 0x29, 0xec, 0x8d, 0x98, 0x64, 0x43, 0x8f, 0xad, 0x30, 0x18, 0x4e, 0x90, 0x8f, 0x27,
+	0x52, 0xcf, 0xd4, 0xb4, 0x7a, 0x96, 0x16, 0x43, 0x70, 0x11, 0xda, 0x3f, 0x28, 0xb3, 0xf1, 0x0e,
+	0x88, 0xbd, 0x70, 0x66, 0x5c, 0x9e, 0x7b, 0xbe, 0x3b, 0xa5, 0x78, 0xbd, 0x40, 0x21, 0xc9, 0x09,
+	0x3c, 0x72, 0xc2, 0xbb, 0x92, 0x90, 0x6f, 0x15, 0x1b, 0x5b, 0xbd, 0xd1, 0xb3, 0x88, 0x1a, 0x67,
+	0xb0, 0x7f, 0xcb, 0x39, 0xd6, 0x5f, 0x87, 0x5c, 0x80, 0x62, 0xe1, 0xc9, 0xd8, 0x3d, 0xae, 0xe0,
+	0xa6, 0x42, 0x1a, 0x73, 0xe3, 0x23, 0xbc, 0x34, 0x27, 0xe8, 0x4e, 0x95, 0x7f, 0x7b, 0xc9, 0xb8,
+	0xc7, 0x1c, 0xee, 0x71, 0xb9, 0xda, 0x08, 0x49, 0x2c, 0x45, 0x4b, 0x2e, 0xe5, 0x1a, 0xaa, 0xff,
+	0x0a, 0xf6, 0x50, 0x61, 0xe4, 0x04, 0x0a, 0x2a, 0x2f, 0x8b, 0xc2, 0x78, 0xd1, 0x3f, 0x7e, 0x42,
+	0x9f, 0x85, 0xd6, 0xf6, 0xc6, 0x68, 0x98, 0x70, 0x40, 0x51, 0x06, 0x1c, 0x97, 0xa8, 0xb2, 0x8a,
+	0xff, 0xd1, 0x3d, 0x85, 0xc3, 0xbb, 0x41, 0x1e, 0xac, 0xf7, 0x35, 0xe4, 0x54, 0x4b, 0x84, 0x9e,
+	0xae, 0x65, 0x92, 0x3a, 0x16, 0xe3, 0xd3, 0x00, 0xe0, 0x66, 0x92, 0xc8, 0x11, 0x94, 0xed, 0x7e,
+	0xbb, 0x3f, 0xb0, 0x87, 0x66, 0xaf, 0x63, 0x0d, 0x07, 0x9f, 0xec, 0xcf, 0x96, 0xd9, 0x7d, 0xdf,
+	0xb5, 0x3a, 0xa5, 0x14, 0x29, 0xc3, 0xfe, 0x2e, 0xb4, 0x07, 0xa6, 0x69, 0xd9, 0x76, 0x49, 0xbb,
+	0x0b, 0xfa, 0xdd, 0x4b, 0xab, 0x37, 0xe8, 0x97, 0xd2, 0xe4, 0x00, 0xf6, 0x76, 0x81, 0x45, 0x69,
+	0x8f, 0x96, 0x32, 0xad, 0x6f, 0x69, 0xc8, 0x77, 0xda, 0x17, 0xa6, 0x8d, 0xc1, 0x92, 0xbb, 0x48,
+	0x3a, 0x90, 0xdf, 0x19, 0x1b, 0xa2, 0xc7, 0x03, 0xfe, 0xd7, 0x18, 0x56, 0x9e, 0x27, 0x90, 0xa8,
+	0x70, 0x23, 0x45, 0x10, 0x0e, 0x93, 0xdb, 0x4d, 0x5e, 0x45, 0x6e, 0xf7, 0x4e, 0x56, 0xe5, 0xf8,
+	0xfe, 0x47, 0xdb, 0x34, 0x97, 0x50, 0xb8, 0xdd, 0x1d, 0x72, 0x14, 0x79, 0x26, 0x36, 0xbe, 0xf2,
+	0x22, 0x19, 0x6e, 0xc2, 0x9d, 0x9f, 0xfd, 0x58, 0x57, 0xb5, 0x9f, 0xeb, 0xaa, 0xf6, 0x6b, 0x5d,
+	0xd5, 0xbe, 0xff, 0xae, 0xa6, 0xbe, 0xbc, 0x19, 0x73, 0x39, 0x59, 0x38, 0x0d, 0xd7, 0x9f, 0x35,
+	0x5d, 0xf4, 0x50, 0x48, 0xce, 0xfc, 0x60, 0xbc, 0x5d, 0x11, 0x4d, 0xb9, 0x9a, 0xa3, 0x68, 0xce,
+	0x1d, 0xb5, 0x4f, 0x9c, 0x9c, 0xda, 0x18, 0x6f, 0xff, 0x04, 0x00, 0x00, 0xff, 0xff, 0x9a, 0xbe,
+	0xc3, 0x8c, 0x63, 0x04, 0x00, 0x00,
 }

--- a/types/pb/dalc/dalc.pb.go
+++ b/types/pb/dalc/dalc.pb.go
@@ -18,17 +18,21 @@
 */
 package dalc
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import optimint "github.com/celestiaorg/optimint/types/pb/optimint"
-
 import (
-	context "golang.org/x/net/context"
-	grpc "google.golang.org/grpc"
-)
+	fmt "fmt"
 
-import io "io"
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+
+	optimint "github.com/celestiaorg/optimint/types/pb/optimint"
+
+	context "golang.org/x/net/context"
+
+	grpc "google.golang.org/grpc"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/types/pb/optimint/optimint.pb.go
+++ b/types/pb/optimint/optimint.pb.go
@@ -16,12 +16,17 @@
 */
 package optimint
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import tendermint_abci "github.com/tendermint/tendermint/abci/types"
+import (
+	fmt "fmt"
 
-import io "io"
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+
+	tendermint_abci "github.com/tendermint/tendermint/abci/types"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/types/pb/optimint/optimint.pb.go
+++ b/types/pb/optimint/optimint.pb.go
@@ -91,7 +91,7 @@ type Header struct {
 	// We keep this in case users choose another signature format where the
 	// pubkey can't be recovered by the signature (e.g. ed25519).
 	ProposerAddress []byte `protobuf:"bytes,11,opt,name=proposer_address,json=proposerAddress,proto3" json:"proposer_address,omitempty"`
-	// Hash of block aggregator set, at a time of block creation.
+	// Hash of block aggregator set, at a time of block creation
 	AggregatorsHash []byte `protobuf:"bytes,12,opt,name=aggregators_hash,json=aggregatorsHash,proto3" json:"aggregators_hash,omitempty"`
 }
 


### PR DESCRIPTION
This PR introduces new DALC API into optimint.

Most important changes:
* BlockManager needs to keep track of DA layer height
* single DA layer block can contain multiple Optimint blocks
* sync is now more complicated - but I tried to keep it as simple as possible

Actually, there's no need to explicitly map DA layer height to Optimint height. 

Resolves #281.