### PR TITLE
fix: keep track of DA height of latest applied block

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -37,6 +37,7 @@ type State struct {
 	LastBlockID     types.BlockID
 	LastBlockTime   time.Time
 
+	// DAHeight identifies DA block containing the latest applied Optimint block.
 	DAHeight uint64
 
 	// In the MVP implementation, there will be only one Validator


### PR DESCRIPTION
Previously, latest processed DA block height was saved, and as a result syncing couldn't restart.

Resolves https://github.com/celestiaorg/optimint/issues/376