### PR TITLE
ci: rename docker build jobs, so they can be not required

### DIFF
--- a/.github/workflows/docker-build-da-mockserv.yml
+++ b/.github/workflows/docker-build-da-mockserv.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: celestiaorg/optimint-mockserv
 
 jobs:
-  build:
+  docker-build:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/docker-build-ethermint-debug.yml
+++ b/.github/workflows/docker-build-ethermint-debug.yml
@@ -15,7 +15,7 @@ env:
   TAG_PREFIX: optimint-
 
 jobs:
-  build:
+  docker-build:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/docker-build-test-ethermint.yml
+++ b/.github/workflows/docker-build-test-ethermint.yml
@@ -15,7 +15,7 @@ env:
   TAG_PREFIX: optimint-
 
 jobs:
-  build:
+  docker-build:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "ubuntu-latest"
     permissions:


### PR DESCRIPTION
Right now, docker jobs are called `build` so it's impossible to exclude them from "Required" checks in branch protection rules.

After renaming, we can make them "Required", but for now I suggest to leave them not-required.