### PR TITLE
Improve WebSockets error handling

### DIFF
--- a/rpc/json/ws.go
+++ b/rpc/json/ws.go
@@ -54,8 +54,9 @@ func (h *handler) wsHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	ws := &wsConn{
-		conn:  wsc,
-		queue: make(chan []byte),
+		conn:   wsc,
+		queue:  make(chan []byte),
+		logger: h.logger,
 	}
 	go ws.sendLoop()
 

--- a/rpc/json/ws.go
+++ b/rpc/json/ws.go
@@ -41,10 +41,11 @@ func (h *handler) wsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wsc, err := upgrader.Upgrade(w, r, nil)
-	remoteAddr := wsc.RemoteAddr().String()
 	if err != nil {
-		h.logger.Error("failed to update to WebSocket connection", "error", err, "address", remoteAddr)
+		h.logger.Error("failed to update to WebSocket connection", "error", err)
+		return
 	}
+	remoteAddr := wsc.RemoteAddr().String()
 	defer func() {
 		err := wsc.Close()
 		if err != nil {
@@ -61,7 +62,8 @@ func (h *handler) wsHandler(w http.ResponseWriter, r *http.Request) {
 	for {
 		mt, r, err := wsc.NextReader()
 		if err != nil {
-			h.logger.Debug("failed to read next WebSocket message", "error", err)
+			h.logger.Error("failed to read next WebSocket message", "error", err)
+			break
 		}
 
 		if mt != websocket.TextMessage {


### PR DESCRIPTION
This PR resolves multiple issues related to error handling in WebSockets.

- even if connection upgrade return error, code tries to get remote address
- `NextReader` errors should exit the read loop
- logger is not passed to `wsConn` handle

Resolves: #326.