### PR TITLE
Ensure JSON serialization compatibility

### DIFF
--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -103,7 +103,13 @@ func (h *handler) serveJSONRPCforWS(w http.ResponseWriter, r *http.Request, wsCo
 
 	// Encode the response.
 	if errResult == nil {
-		codecReq.WriteResponse(w, rets[0].Interface())
+		var raw json.RawMessage
+		raw, err = tmjson.Marshal(rets[0].Interface())
+		if err != nil {
+			codecReq.WriteError(w, http.StatusInternalServerError, err)
+			return
+		}
+		codecReq.WriteResponse(w, raw)
 	} else {
 		codecReq.WriteError(w, statusCode, errResult)
 	}

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"strconv"
 
+	tmjson "github.com/tendermint/tendermint/libs/json"
+
 	"github.com/celestiaorg/optimint/log"
 	"github.com/gorilla/rpc/v2"
 	"github.com/gorilla/rpc/v2/json2"
@@ -176,7 +178,12 @@ func (h *handler) encodeAndWriteResponse(w http.ResponseWriter, result interface
 	if errResult != nil {
 		resp.Error = &json2.Error{Code: json2.ErrorCode(statusCode), Data: errResult.Error()}
 	} else {
-		resp.Result = result
+		bytes, err := tmjson.Marshal(result)
+		if err != nil {
+			resp.Error = &json2.Error{Code: json2.ErrorCode(json2.E_INTERNAL), Data: err.Error()}
+		} else {
+			resp.Result = bytes
+		}
 	}
 
 	encoder := json.NewEncoder(w)

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -134,7 +134,7 @@ func TestStringyRequest(t *testing.T) {
 	// `starport chain faucet ...` generates broken JSON (ints are "quoted" as strings)
 	brokenJSON := `{"jsonrpc":"2.0","id":0,"method":"tx_search","params":{"order_by":"","page":"1","per_page":"1000","prove":true,"query":"message.sender='cosmos1njr26e02fjcq3schxstv458a3w5szp678h23dh' AND transfer.recipient='cosmos1e0ajth0s847kqcu2ssnhut32fsrptf94fqnfzx'"}}`
 
-	respJson := `{"jsonrpc":"2.0","result":{"txs":[],"total_count":0},"id":0}` + "\n"
+	respJson := `{"jsonrpc":"2.0","result":{"txs":[],"total_count":"0"},"id":0}` + "\n"
 
 	req := httptest.NewRequest(http.MethodGet, "/", strings.NewReader(brokenJSON))
 	resp := httptest.NewRecorder()

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -68,13 +68,13 @@ func TestREST(t *testing.T) {
 
 		{"invalid/malformed request", "/block?so{}wrong!", http.StatusOK, int(json2.E_INVALID_REQ), ``},
 		{"invalid/missing param", "/block", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'height'`},
-		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":345`},
+		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		// to keep test simple, allow returning application error in following case
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), `"key not found"`},
 		{"invalid/int param", "/block?height=foo", http.StatusOK, int(json2.E_PARSE), "failed to parse param 'height'"},
 		{"valid/bool int string params",
 			"/tx_search?" + txSearchParams.Encode(),
-			http.StatusOK, -1, `"total_count":0`},
+			http.StatusOK, -1, `"total_count":"0"`},
 		{"invalid/bool int string params",
 			"/tx_search?" + strings.Replace(txSearchParams.Encode(), "true", "blue", 1),
 			http.StatusOK, int(json2.E_PARSE), "failed to parse param 'prove'"},

--- a/rpc/json/types.go
+++ b/rpc/json/types.go
@@ -161,7 +161,7 @@ func unmarshalStrInt64(b []byte, s *StrInt64) error {
 
 type response struct {
 	Version string          `json:"jsonrpc"`
-	Result  interface{}     `json:"result,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *json2.Error    `json:"error,omitempty"`
 	Id      json.RawMessage `json:"id"`
 }


### PR DESCRIPTION
Because Tendermint encodes ints as strings, and expects strings while
decoding, Optimint has to encode int values as strings as well.

This PR ensures that Tendermint JSON library is used for encoding of results both in plain HTTP requests and JSON RPC requests.

Resolves #463.