### PR TITLE
chore: move initGenesisChunks call into GetGenesisChunks

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -234,6 +234,9 @@ func (n *Node) GetGenesis() *tmtypes.GenesisDoc {
 // GetGenesisChunks returns chunked version of genesis.
 func (n *Node) GetGenesisChunks() ([]string, error) {
 	err := n.initGenesisChunks()
+	if err != nil {
+		return nil, err
+	}
 	return n.genChunks, err
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -215,10 +215,6 @@ func (n *Node) OnStart() error {
 	if err != nil {
 		return fmt.Errorf("error while starting data availability layer client: %w", err)
 	}
-	err = n.initGenesisChunks()
-	if err != nil {
-		return fmt.Errorf("error while creating chunks of the genesis document: %w", err)
-	}
 	if n.conf.Aggregator {
 		n.Logger.Info("working in aggregator mode", "block time", n.conf.BlockTime)
 		go n.blockManager.AggregationLoop(n.ctx)
@@ -237,6 +233,10 @@ func (n *Node) GetGenesis() *tmtypes.GenesisDoc {
 
 // GetGenesisChunks returns chunked version of genesis.
 func (n *Node) GetGenesisChunks() []string {
+	err := n.initGenesisChunks()
+	if err != nil {
+		n.Logger.Error("error while creating chunks of the genesis document: %w", err)
+	}
 	return n.genChunks
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -232,12 +232,9 @@ func (n *Node) GetGenesis() *tmtypes.GenesisDoc {
 }
 
 // GetGenesisChunks returns chunked version of genesis.
-func (n *Node) GetGenesisChunks() []string {
+func (n *Node) GetGenesisChunks() ([]string, error) {
 	err := n.initGenesisChunks()
-	if err != nil {
-		n.Logger.Error("error while creating chunks of the genesis document: %w", err)
-	}
-	return n.genChunks
+	return n.genChunks, err
 }
 
 // OnStop is a part of Service interface.

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -275,7 +275,10 @@ func (c *Client) Genesis(_ context.Context) (*ctypes.ResultGenesis, error) {
 
 // GenesisChunked returns given chunk of genesis.
 func (c *Client) GenesisChunked(context context.Context, id uint) (*ctypes.ResultGenesisChunk, error) {
-	genChunks := c.node.GetGenesisChunks()
+	genChunks, err := c.node.GetGenesisChunks()
+	if err != nil {
+		return nil, fmt.Errorf("error while creating chunks of the genesis document: %w", err)
+	}
 	if genChunks == nil {
 		return nil, fmt.Errorf("service configuration error, genesis chunks are not initialized")
 	}


### PR DESCRIPTION
Resolves #470 (I think?) 

Should the error handling from `initGenesisChunks` be kept inside `GetGenesisChunks`, or be passed to `GenesisChunked` ? 