### PR TITLE
feat: support Commit gossiping on P2P level

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -59,6 +59,9 @@ type Manager struct {
 	HeaderOutCh chan *types.Header
 	HeaderInCh  chan *types.Header
 
+	CommitInCh  chan *types.Commit
+	CommitOutCh chan *types.Commit
+
 	syncTarget uint64
 	blockInCh  chan newBlockEvent
 	syncCache  map[uint64]*types.Block
@@ -136,6 +139,8 @@ func NewManager(
 		// channels are buffered to avoid blocking on input/output operations, buffer sizes are arbitrary
 		HeaderOutCh: make(chan *types.Header, 100),
 		HeaderInCh:  make(chan *types.Header, 100),
+		CommitInCh:  make(chan *types.Commit, 100),
+		CommitOutCh: make(chan *types.Commit, 100),
 		blockInCh:   make(chan newBlockEvent, 100),
 		retrieveMtx: new(sync.Mutex),
 		syncCache:   make(map[uint64]*types.Block),

--- a/node/node.go
+++ b/node/node.go
@@ -154,6 +154,7 @@ func NewNode(ctx context.Context, conf config.NodeConfig, p2pKey crypto.PrivKey,
 
 	node.P2P.SetTxValidator(node.newTxValidator())
 	node.P2P.SetHeaderValidator(node.newHeaderValidator())
+	node.P2P.SetCommitValidator(node.newCommitValidator())
 
 	return node, nil
 }
@@ -320,6 +321,27 @@ func (n *Node) newHeaderValidator() p2p.GossipValidator {
 			return false
 		}
 		n.blockManager.HeaderInCh <- &header
+		return true
+	}
+}
+
+// newCommitValidator returns a pubsub validator that runs basic checks and forwards
+// the deserialized commit for further processing
+func (n *Node) newCommitValidator() p2p.GossipValidator {
+	return func(commitMsg *p2p.GossipMessage) bool {
+		n.Logger.Debug("commit received", "from", commitMsg.From, "bytes", len(commitMsg.Data))
+		var commit types.Commit
+		err := commit.UnmarshalBinary(commitMsg.Data)
+		if err != nil {
+			n.Logger.Error("failed to deserialize commit", "error", err)
+			return false
+		}
+		err = commit.ValidateBasic()
+		if err != nil {
+			n.Logger.Error("failed to validate commit", "error", err)
+			return false
+		}
+		n.blockManager.CommitInCh <- &commit
 		return true
 	}
 }


### PR DESCRIPTION
This PR introduces `Commit` gossiping logic. Only the latest commit is interesting for full nodes (as older ones are available in DA).
Work will be continued in future PRs.

Resolves #479.