### PR TITLE
feat: pass namespace ID to DA layers

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -88,7 +88,7 @@ func TestInitialState(t *testing.T) {
 
 func getMockDALC(logger log.Logger) da.DataAvailabilityLayerClient {
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	_ = dalc.Init(nil, nil, logger)
+	_ = dalc.Init([8]byte{}, nil, nil, logger)
 	_ = dalc.Start()
 	return dalc
 }

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -39,7 +39,7 @@ func NewServer(blockTime time.Duration, logger log.Logger) *Server {
 
 // Start starts HTTP server with given listener.
 func (s *Server) Start(listener net.Listener) error {
-	err := s.mock.Init([]byte(s.blockTime.String()), store.NewDefaultInMemoryKVStore(), s.logger)
+	err := s.mock.Init([8]byte{}, []byte(s.blockTime.String()), store.NewDefaultInMemoryKVStore(), s.logger)
 	if err != nil {
 		return err
 	}

--- a/da/da.go
+++ b/da/da.go
@@ -58,7 +58,7 @@ type ResultRetrieveBlocks struct {
 // It also contains life-cycle methods.
 type DataAvailabilityLayerClient interface {
 	// Init is called once to allow DA client to read configuration and initialize resources.
-	Init(config []byte, kvStore store.KVStore, logger log.Logger) error
+	Init(namespaceID [8]byte, config []byte, kvStore store.KVStore, logger log.Logger) error
 
 	// Start is called once, after Init. It's implementation should start operation of DataAvailabilityLayerClient.
 	Start() error

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -41,7 +41,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init sets the configuration options.
-func (d *DataAvailabilityLayerClient) Init(config []byte, _ store.KVStore, logger log.Logger) error {
+func (d *DataAvailabilityLayerClient) Init(_ [8]byte, config []byte, _ store.KVStore, logger log.Logger) error {
 	d.logger = logger
 	if len(config) == 0 {
 		d.config = DefaultConfig

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -21,7 +21,7 @@ func GetServer(kv store.KVStore, conf grpcda.Config, mockConfig []byte) *grpc.Se
 
 	srv := grpc.NewServer()
 	mockImpl := &mockImpl{}
-	err := mockImpl.mock.Init(mockConfig, kv, logger)
+	err := mockImpl.mock.Init([8]byte{}, mockConfig, kv, logger)
 	if err != nil {
 		logger.Error("failed to initialize mock DALC", "error", err)
 		panic(err)

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -31,7 +31,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init is called once to allow DA client to read configuration and initialize resources.
-func (m *DataAvailabilityLayerClient) Init(config []byte, dalcKV store.KVStore, logger log.Logger) error {
+func (m *DataAvailabilityLayerClient) Init(_ [8]byte, config []byte, dalcKV store.KVStore, logger log.Logger) error {
 	m.logger = logger
 	m.dalcKV = dalcKV
 	m.daHeight = 1

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -26,6 +26,8 @@ import (
 
 const mockDaBlockTime = 100 * time.Millisecond
 
+var testNamespaceID = [8]byte{0, 1, 2, 3, 4, 5, 6, 7}
+
 func TestLifecycle(t *testing.T) {
 	srv := startMockGRPCServ(t)
 	defer srv.GracefulStop()
@@ -40,7 +42,7 @@ func TestLifecycle(t *testing.T) {
 func doTestLifecycle(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	require := require.New(t)
 
-	err := dalc.Init([]byte{}, nil, test.NewLogger(t))
+	err := dalc.Init(testNamespaceID, []byte{}, nil, test.NewLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -75,14 +77,13 @@ func doTestDALC(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	}
 	if _, ok := dalc.(*celestia.DataAvailabilityLayerClient); ok {
 		config := celestia.Config{
-			BaseURL:     "http://localhost:26658",
-			Timeout:     30 * time.Second,
-			GasLimit:    3000000,
-			NamespaceID: [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+			BaseURL:  "http://localhost:26658",
+			Timeout:  30 * time.Second,
+			GasLimit: 3000000,
 		}
 		conf, _ = json.Marshal(config)
 	}
-	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
+	err := dalc.Init(testNamespaceID, conf, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()
@@ -177,14 +178,13 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	}
 	if _, ok := dalc.(*celestia.DataAvailabilityLayerClient); ok {
 		config := celestia.Config{
-			BaseURL:     "http://localhost:26658",
-			Timeout:     30 * time.Second,
-			GasLimit:    3000000,
-			NamespaceID: [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+			BaseURL:  "http://localhost:26658",
+			Timeout:  30 * time.Second,
+			GasLimit: 3000000,
 		}
 		conf, _ = json.Marshal(config)
 	}
-	err := dalc.Init(conf, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
+	err := dalc.Init(testNamespaceID, conf, store.NewDefaultInMemoryKVStore(), test.NewLogger(t))
 	require.NoError(err)
 
 	err = dalc.Start()

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -171,7 +171,7 @@ func createNodes(num int, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.A
 	nodes := make([]*Node, num)
 	apps := make([]*mocks.Application, num)
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	_ = dalc.Init(nil, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
+	_ = dalc.Init([8]byte{}, nil, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
 	_ = dalc.Start()
 
 	nodes[0], apps[0] = createNode(0, true, dalc, keys, wg, t)

--- a/node/node.go
+++ b/node/node.go
@@ -114,7 +114,7 @@ func NewNode(ctx context.Context, conf config.NodeConfig, p2pKey crypto.PrivKey,
 	if dalc == nil {
 		return nil, fmt.Errorf("couldn't get data availability client named '%s'", conf.DALayer)
 	}
-	err = dalc.Init([]byte(conf.DAConfig), dalcKV, logger.With("module", "da_client"))
+	err = dalc.Init(conf.NamespaceID, []byte(conf.DAConfig), dalcKV, logger.With("module", "da_client"))
 	if err != nil {
 		return nil, fmt.Errorf("data availability layer client initialization error: %w", err)
 	}


### PR DESCRIPTION
NamespaceID is removed from Celestia DA configuration. Instead, it's added to DA interface. Mocks simply ignore this. 

Resolves #425.