### PR TITLE
Use context in integration test

### DIFF
--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -118,7 +118,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 	for _, n := range nodes {
 		require.NoError(n.Stop())
 	}
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	aggApp := apps[0]
 	apps = apps[1:]
 


### PR DESCRIPTION
Using cancelable context in integration tests allows proper shutdown of nodes. 

Resolves #531.